### PR TITLE
Move ByteArrayBuffer to jitsi-utils

### DIFF
--- a/src/main/java/org/jitsi/utils/ByteArrayBuffer.java
+++ b/src/main/java/org/jitsi/utils/ByteArrayBuffer.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright @ 2015 - present 8x8, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.utils;
+
+/**
+ * A simple interface that encapsulates all the information needed for byte
+ * buffer access.
+ *
+ * @author George Politis
+ */
+public interface ByteArrayBuffer
+{
+    /**
+     * Gets the byte buffer that supports this instance.
+     *
+     * @return the byte buffer that supports this instance.
+     */
+    byte[] getBuffer();
+
+    /**
+     * Gets the offset in the byte buffer where the actual data starts.
+     *
+     * @return the offset in the byte buffer where the actual data starts.
+     */
+    int getOffset();
+
+    /**
+     * Gets the length of the data in the buffer.
+     *
+     * @return the length of the data in the buffer.
+     */
+    int getLength();
+
+    /**
+     * Sets the length of the data in the buffer.
+     *
+     * @param len the length of the data in the buffer.
+     */
+    void setLength(int len);
+
+    /**
+     * Sets the offset of the data in the buffer.
+     *
+     * @param off the offset of the data in the buffer.
+     */
+    void setOffset(int off);
+
+    /**
+     * Perform checks on the byte buffer represented by this instance and
+     * return <tt>true</tt> if it is found to be invalid.
+     *
+     * @return <tt>true</tt> if the byte buffer represented by this
+     * instance is found to be invalid, <tt>false</tt> otherwise.
+     */
+    boolean isInvalid();
+
+    /**
+     * Copies {@code len} bytes from the given offset in this buffer to the given {@code outBuf}
+     * @param off the offset relative to the beginning of this buffer's data from where to start copying.
+     * @param len the number of bytes to copy.
+     * @param outBuf the array to copy to
+     */
+    void readRegionToBuff(int off, int len, byte[] outBuf);
+
+    /**
+     * Increases the size of this buffer by {@code howMuch}. This may result in a new {@code byte[]} to be allocated
+     * if the existing one is not large enough.
+     * @param howMuch
+     */
+    void grow(int howMuch);
+
+    /**
+     * Appends {@code len} bytes from {@code data} to the end of this buffer. This grows the buffer and as a result
+     * a new {@code byte[]} may be allocated.
+     * @param data
+     * @param len
+     */
+    void append(byte[] data, int len);
+
+    /**
+     * Shrinks the length of this buffer by {@code len}
+     * @param len
+     */
+    void shrink(int len);
+}

--- a/src/main/java/org/jitsi/utils/TimestampUtils.java
+++ b/src/main/java/org/jitsi/utils/TimestampUtils.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright @ 2017 - present 8x8 Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.utils;
+
+/**
+ * Helper class to perform various timestamp manipulations and comparisons
+ * @author Ethan Lin
+ */
+public class TimestampUtils
+{
+    // RTP timestamp is 32 bits, this represents the maximum value of an RTP timestamp
+    public static final long MAX_TIMESTAMP_VALUE = Long.MAX_VALUE & 0xFFFF_FFFFL;
+    // (Roughly) half of the MAX_TIMESTAMP_VALUE.  Used when we're trying to compare
+    // two timestamps to determine which came 'first'.
+    public static final long ROLLOVER_DELTA_VALUE = 0x8000_0000L;
+    /**
+     * Calculate the subtraction result of two long input as unsigned 32bit int.
+     *
+     * @param t1 the first timestamp
+     * @param t2 the second timestamp
+     * @return
+     */
+    public static long subtractAsUnsignedInt32(long t1, long t2)
+    {
+        return (t1 - t2) & 0xFFFF_FFFFL;
+    }
+
+    /**
+     * Returns true if t1 is newer than t2,
+     * taking into account rollover.  This is done by effectively
+     * checking if the distance of going from 't2' to
+     * 't1' (strictly incrementing) is shorter or if going from
+     * 't1' to 't2' (i.e. rolling over) is shorter.
+     * webrtc/modules/include/module_common_types.h
+     *
+     * @param t1
+     * @param t2
+     * @return true if t1 is newer
+     */
+    public static boolean isNewerTimestamp(long t1, long t2)
+    {
+        if (t1 == t2)
+        {
+            return false;
+        }
+        // Distinguish between elements that are exactly ROLLOVER_DELTA_VALUE apart.
+        // If t1 > t2 and |t1-t2| == ROLLOVER_DELTA_VALUE:
+        // isNewerTimestamp(t1,t2) = true,
+        // isNewerTimestamp(t2,t1) = false
+        // rather than having:
+        // isNewerTimestamp(t1,t2) = isNewerTimestamp(t2,t1) = false.
+        if (subtractAsUnsignedInt32(t1, t2) == ROLLOVER_DELTA_VALUE)
+        {
+            // The two timestamps are exactly ROLLOVER_DELTA_VALUE apart, so
+            // we can't guess which is newer.  To break the tie, assume
+            // the larger timestamp is newer.
+            return t1 > t2;
+        }
+        return subtractAsUnsignedInt32(t1, t2) < ROLLOVER_DELTA_VALUE;
+    }
+
+    /**
+     * webrtc/modules/include/module_common_types.h
+     *
+     * @param timestamp1
+     * @param timestamp2
+     * @return
+     */
+    public static long latestTimestamp(long timestamp1, long timestamp2)
+    {
+        return
+            isNewerTimestamp(timestamp1, timestamp2) ? timestamp1 : timestamp2;
+    }
+}

--- a/src/main/java/org/jitsi/utils/queue/QueueStatistics.java
+++ b/src/main/java/org/jitsi/utils/queue/QueueStatistics.java
@@ -106,7 +106,7 @@ public class QueueStatistics
      * @param now the time (in milliseconds since the epoch) at which the
      * packet was added.
      */
-    void add(long now)
+    public void add(long now)
     {
         if (firstPacketAddedMs < 0)
         {
@@ -121,7 +121,7 @@ public class QueueStatistics
      * @param now the time (in milliseconds since the epoch) at which the
      * packet was removed.
      */
-    void remove(long now)
+    public void remove(long now)
     {
         removeRate.update(1, now);
         totalPacketsRemoved.incrementAndGet();
@@ -132,7 +132,7 @@ public class QueueStatistics
      * @param now the time (in milliseconds since the epoch) at which the
      * packet was dropped.
      */
-    void drop(long now)
+    public void drop(long now)
     {
         dropRate.update(1, now);
         totalPacketsDropped.incrementAndGet();

--- a/src/test/java/org/jitsi/utils/TimestampUtilsTest.java
+++ b/src/test/java/org/jitsi/utils/TimestampUtilsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright @ 2017 - present 8x8, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.utils;
+
+import org.junit.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Ethan Lin
+ */
+public class TimestampUtilsTest
+{
+    private final static long kBoundary = 0x8000_0000L;
+
+    @Test
+    public void testTimestampIsNewer()
+    {
+        assertEquals(true, TimestampUtils.isNewerTimestamp(1L, 0L));
+        assertEquals(true, TimestampUtils.isNewerTimestamp(0L, kBoundary + 1L));
+        assertEquals(true, TimestampUtils.isNewerTimestamp(kBoundary, 0L));
+    }
+
+    @Test
+    public void testTimestampIsOlder()
+    {
+        assertEquals(false, TimestampUtils.isNewerTimestamp(0L, 1L));
+        assertEquals(false, TimestampUtils.isNewerTimestamp(0L, kBoundary));
+    }
+
+    @Test
+    public void returnLatestTimestamp()
+    {
+        assertEquals(1L, TimestampUtils.latestTimestamp(1L, 0L));
+        assertEquals(0L, TimestampUtils.latestTimestamp(0L, kBoundary + 1));
+        assertEquals(kBoundary, TimestampUtils.latestTimestamp(1L, kBoundary));
+    }
+
+}
+


### PR DESCRIPTION
Makes ByteArrayBuffer an interface in jitsi-utils. Libjitsi (and jitsi-rtp) will be modified to implement the interface. Also moves TimestampUtils and exposes some of the methods of QueueStatistics.