### PR TITLE
Exclude json-simple's compile dependency on junit.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,14 @@
       <groupId>com.googlecode.json-simple</groupId>
       <artifactId>json-simple</artifactId>
       <version>1.1.1</version>
+      <!-- json-simple 1.1.1 incorrectly listed junit as a compile dependency rather than a test dependency.
+	   This has been fixed in its github repo but a new release hasn't been pushed to maven. -->
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jetbrains</groupId>


### PR DESCRIPTION
(This is fixed in json-simple's github repo, but they haven't pushed a maven release with the fix yet.)