### PR TITLE
add wrappers for msg supplier log methods

### DIFF
--- a/src/main/java/org/jitsi/utils/logging2/Logger.java
+++ b/src/main/java/org/jitsi/utils/logging2/Logger.java
@@ -17,6 +17,7 @@
 package org.jitsi.utils.logging2;
 
 import java.util.*;
+import java.util.function.*;
 import java.util.logging.*;
 
 public interface Logger
@@ -57,6 +58,15 @@ public interface Logger
     void trace(Object msg);
 
     /**
+     * Log a TRACE message.  Only invokes the given supplier
+     * if the TRACE level is currently loggable.
+     *
+     * @param msgSupplier a {@link Supplier} which will return the
+     *                    log mesage when invoked
+     */
+    void trace(Supplier<String> msgSupplier);
+
+    /**
      * Check if a message with a DEBUG level would actually be logged by this
      * logger.
      * <p>
@@ -76,6 +86,15 @@ public interface Logger
     void debug(Object msg);
 
     /**
+     * Log a DEBUG message.  Only invokes the given supplier
+     * if the DEBUG level is currently loggable.
+     *
+     * @param msgSupplier a {@link Supplier} which will return the
+     *                    log mesage when invoked
+     */
+    void debug(Supplier<String> msgSupplier);
+
+    /**
      * Check if a message with an INFO level would actually be logged by this
      * logger.
      *
@@ -84,7 +103,7 @@ public interface Logger
     boolean isInfoEnabled();
 
     /**
-     * Log a INFO message.
+     * Log an INFO message.
      * <p>
      * If the logger is currently enabled for the INFO message
      * level then the given message is forwarded to all the
@@ -93,6 +112,15 @@ public interface Logger
      * @param msg The message to log
      */
     void info(Object msg);
+
+    /**
+     * Log an INFO message.  Only invokes the given supplier
+     * if the INFO level is currently loggable.
+     *
+     * @param msgSupplier a {@link Supplier} which will return the
+     *                    log mesage when invoked
+     */
+    void info(Supplier<String> msgSupplier);
 
     /**
      * Check if a message with a WARN level would actually be logged by this
@@ -114,6 +142,15 @@ public interface Logger
     void warn(Object msg);
 
     /**
+     * Log a WARN message.  Only invokes the given supplier
+     * if the WARN level is currently loggable.
+     *
+     * @param msgSupplier a {@link Supplier} which will return the
+     *                    log mesage when invoked
+     */
+    void warn(Supplier<String> msgSupplier);
+
+    /**
      * Log a message, with associated Throwable information.
      * <p>
      * @param msg   The message to log
@@ -131,6 +168,15 @@ public interface Logger
      * @param msg The message to log
      */
     void error(Object msg);
+
+    /**
+     * Log an ERROR message.  Only invokes the given supplier
+     * if the ERROR level is currently loggable.
+     *
+     * @param msgSupplier a {@link Supplier} which will return the
+     *                    log mesage when invoked
+     */
+    void error(Supplier<String> msgSupplier);
 
     /**
      * Log a message, with associated Throwable information.

--- a/src/main/java/org/jitsi/utils/logging2/LoggerImpl.java
+++ b/src/main/java/org/jitsi/utils/logging2/LoggerImpl.java
@@ -30,7 +30,7 @@ public class LoggerImpl implements Logger
 
     /**
      * The 'minimum' level a log statement must be to be logged by this Logger. For example, if this
-     * is set to {@link Level.WARNING}, then only log statements at the warning level or above
+     * is set to {@link Level#WARNING}, then only log statements at the warning level or above
      * will actually be logged.
      */
     private final Level minLogLevel;
@@ -103,6 +103,16 @@ public class LoggerImpl implements Logger
             return;
         }
         LogRecord lr = new ContextLogRecord(level, msg.toString(), logContext.formattedContext);
+        loggerDelegate.log(lr);
+    }
+
+    private void log(Level level, Supplier<String> msgSupplier)
+    {
+        if (!isLoggable(level))
+        {
+            return;
+        }
+        LogRecord lr = new ContextLogRecord(level, msgSupplier.get(), logContext.formattedContext);
         loggerDelegate.log(lr);
     }
 
@@ -181,6 +191,12 @@ public class LoggerImpl implements Logger
     }
 
     @Override
+    public void trace(Supplier<String> msgSupplier)
+    {
+        log(Level.FINER, msgSupplier);
+    }
+
+    @Override
     public boolean isDebugEnabled() {
         return isLoggable(Level.FINE);
     }
@@ -189,6 +205,12 @@ public class LoggerImpl implements Logger
     public void debug(Object msg)
     {
         log(Level.FINE, msg);
+    }
+
+    @Override
+    public void debug(Supplier<String> msgSupplier)
+    {
+        log(Level.FINE, msgSupplier);
     }
 
     @Override
@@ -204,6 +226,12 @@ public class LoggerImpl implements Logger
     }
 
     @Override
+    public void info(Supplier<String> msgSupplier)
+    {
+       log(Level.INFO, msgSupplier);
+    }
+
+    @Override
     public boolean isWarnEnabled()
     {
         return isLoggable(Level.WARNING);
@@ -216,6 +244,12 @@ public class LoggerImpl implements Logger
     }
 
     @Override
+    public void warn(Supplier<String> msgSupplier)
+    {
+        log(Level.WARNING, msgSupplier);
+    }
+
+    @Override
     public void warn(Object msg, Throwable t)
     {
         log(Level.WARNING, msg, t);
@@ -225,6 +259,12 @@ public class LoggerImpl implements Logger
     public void error(Object msg)
     {
         log(Level.SEVERE, msg);
+    }
+
+    @Override
+    public void error(Supplier<String> msgSupplier)
+    {
+        log(Level.SEVERE, msgSupplier);
     }
 
     @Override

--- a/src/test/java/org/jitsi/utils/logging2/LoggerImplTest.java
+++ b/src/test/java/org/jitsi/utils/logging2/LoggerImplTest.java
@@ -172,6 +172,17 @@ public class LoggerImplTest
         assertEquals(1, childLoggerDelegate.logLines.size());
     }
 
+    @Test
+    public void testMsgSupplier()
+    {
+        LoggerImpl logger = new LoggerImpl("test");
+        logger.setLevel(Level.INFO);
+
+        logger.debug(() -> { throw new RuntimeException("This shouldn't run"); });
+
+        logger.info(() -> "hello, world!");
+        assertEquals(1, fakeLogger.logLines.size());
+    }
 }
 
 class FakeLogger extends java.util.logging.Logger


### PR DESCRIPTION
when looking through the logger i noticed these methods existed to be able to avoid calling things like `isDebugEnabled` first, so thought i would add some wrappers for them.  i have a PR in the bridge that migrates a bunch of stuff to the new logger and leverages these.