### PR TITLE
set the logger name on the log record

### DIFF
--- a/src/main/java/org/jitsi/utils/logging2/LoggerImpl.java
+++ b/src/main/java/org/jitsi/utils/logging2/LoggerImpl.java
@@ -93,6 +93,7 @@ public class LoggerImpl implements Logger
         }
         LogRecord lr = new ContextLogRecord(level, msg.toString(), logContext.formattedContext);
         lr.setThrown(thrown);
+        lr.setLoggerName(this.loggerDelegate.getName());
         loggerDelegate.log(lr);
     }
 
@@ -103,6 +104,7 @@ public class LoggerImpl implements Logger
             return;
         }
         LogRecord lr = new ContextLogRecord(level, msg.toString(), logContext.formattedContext);
+        lr.setLoggerName(this.loggerDelegate.getName());
         loggerDelegate.log(lr);
     }
 
@@ -113,6 +115,7 @@ public class LoggerImpl implements Logger
             return;
         }
         LogRecord lr = new ContextLogRecord(level, msgSupplier.get(), logContext.formattedContext);
+        lr.setLoggerName(this.loggerDelegate.getName());
         loggerDelegate.log(lr);
     }
 


### PR DESCRIPTION
the old log formatter relied on this, so this makes the new logger
backwards compatible with the old log formatter