### PR TITLE
Fixed construction of JSONObject.

### DIFF
--- a/src/main/java/org/jitsi/utils/dsi/DominantSpeakerIdentification.java
+++ b/src/main/java/org/jitsi/utils/dsi/DominantSpeakerIdentification.java
@@ -399,8 +399,7 @@ public class DominantSpeakerIdentification
 
                 // speakers
                 Collection<Speaker> speakersCollection = this.speakers.values();
-                JSONObject[] speakersArray = new JSONObject[speakers.size()];
-                int i = 0;
+                JSONArray speakersArray = new JSONArray();
 
                 for (Speaker speaker : speakersCollection)
                 {
@@ -410,7 +409,7 @@ public class DominantSpeakerIdentification
                     speakerJSONObject.put("ssrc", Long.valueOf(speaker.ssrc));
                     // levels
                     speakerJSONObject.put("levels", speaker.getLevels());
-                    speakersArray[i++] = speakerJSONObject;
+                    speakersArray.add(speakerJSONObject);
                 }
                 jsonObject.put("speakers", speakersArray);
             }


### PR DESCRIPTION
This fixes incorrect `JSON` serialization.
Before it was:
```
...
{
    "dominantSpeakerIdentification": {
        "speakers": [Lorg.json.simple.JSONObject;@5249613,
            "dominantSpeaker": null
        },
        "dominantEndpoint": "Supervisor-be251e68ddb65322"
}
...
```
With proposed changes:
```
...
{
    "dominantSpeakerIdentification": {
        "speakers": [],
        "dominantSpeaker": null
    }
}
...
```