### PR TITLE
Support adding log context after LogContext creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,12 @@
       <artifactId>jna</artifactId>
       <version>4.1.0</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>19.0</version>
+    </dependency>
+
 
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/org/jitsi/utils/logging2/LogContext.java
+++ b/src/main/java/org/jitsi/utils/logging2/LogContext.java
@@ -154,18 +154,14 @@ public class LogContext
         return ImmutableMap.copyOf(combinedMap);
     }
 
-    @SafeVarargs
-    protected static String formatContext(Map<String, String>... contexts)
+    protected static String formatContext(Map<String, String> context)
     {
         StringBuilder contextString = new StringBuilder();
-        for (Map<String, String> context : contexts)
-        {
-            String data = context.entrySet()
-                    .stream()
-                    .map(e -> e.getKey() + "=" + e.getValue())
-                    .collect(Collectors.joining(" "));
-            contextString.append(data);
-        }
+        String data = context.entrySet()
+                .stream()
+                .map(e -> e.getKey() + "=" + e.getValue())
+                .collect(Collectors.joining(" "));
+        contextString.append(data);
         if (contextString.length() > 0)
         {
             return CONTEXT_START_TOKEN +

--- a/src/main/java/org/jitsi/utils/logging2/LogContext.java
+++ b/src/main/java/org/jitsi/utils/logging2/LogContext.java
@@ -16,6 +16,7 @@
 
 package org.jitsi.utils.logging2;
 
+import com.google.common.collect.*;
 import org.jetbrains.annotations.*;
 import org.jitsi.utils.collections.*;
 
@@ -38,21 +39,21 @@ public class LogContext
     public static String CONTEXT_START_TOKEN = "[";
     public static String CONTEXT_END_TOKEN = "]";
 
-    protected Map<String, String> parentContext;
-    protected Map<String, String> context;
+    protected ImmutableMap<String, String> parentContext;
+    protected ImmutableMap<String, String> context;
 
     protected String formattedContext;
     private final List<LogContext> childContexts = new CopyOnWriteArrayList<>();
 
     public LogContext(Map<String, String> context)
     {
-        this(context, new HashMap<>());
+        this(context, ImmutableMap.of());
     }
 
-    protected LogContext(Map<String, String> context, Map<String, String> parentContext)
+    protected LogContext(Map<String, String> context, ImmutableMap<String, String> parentContext)
     {
-        this.context = Collections.unmodifiableMap(context);
-        this.parentContext = Collections.unmodifiableMap(parentContext);
+        this.context = ImmutableMap.copyOf(context);
+        this.parentContext = parentContext;
         updateFormattedContext();
     }
 
@@ -90,7 +91,7 @@ public class LogContext
     {
         // The parent context to this child is the combination of this LogContext's context
         // and its parent's context
-        Map<String, String> combinedParentContext = combineMaps(parentContext, context);
+        ImmutableMap<String, String> combinedParentContext = combineMaps(parentContext, context);
         LogContext child = new LogContext(childContextData, combinedParentContext);
         childContexts.add(child);
         return child;
@@ -109,13 +110,13 @@ public class LogContext
 
     protected void updateChildren()
     {
-        Map<String, String> combined = combineMaps(parentContext, context);
-       childContexts.forEach((child) -> child.parentContextUpdated(combined));
+        ImmutableMap<String, String> combined = combineMaps(parentContext, context);
+        childContexts.forEach((child) -> child.parentContextUpdated(combined));
     }
 
-    protected void parentContextUpdated(Map<String, String> parentContext)
+    protected void parentContextUpdated(ImmutableMap<String, String> parentContext)
     {
-        this.parentContext = Collections.unmodifiableMap(parentContext);
+        this.parentContext = parentContext;
         updateFormattedContext();
     }
 
@@ -127,14 +128,14 @@ public class LogContext
      */
     @SafeVarargs
     @NotNull
-    protected static Map<String, String> combineMaps(@NotNull Map<String, String>... maps)
+    protected static ImmutableMap<String, String> combineMaps(@NotNull Map<String, String>... maps)
     {
         Map<String, String> combinedMap = new HashMap<>();
         for (Map<String, String> map : maps)
         {
             combinedMap.putAll(map);
         }
-        return Collections.unmodifiableMap(combinedMap);
+        return ImmutableMap.copyOf(combinedMap);
     }
 
     @Override

--- a/src/main/java/org/jitsi/utils/logging2/LogContext.java
+++ b/src/main/java/org/jitsi/utils/logging2/LogContext.java
@@ -39,10 +39,27 @@ public class LogContext
     public static String CONTEXT_START_TOKEN = "[";
     public static String CONTEXT_END_TOKEN = "]";
 
+    /**
+     * All context belonging to 'ancestors' of  this
+     * LogContext
+     */
     protected ImmutableMap<String, String> parentContext;
+    /**
+     * The context held by this specific LogContext.
+     */
     protected ImmutableMap<String, String> context;
 
+    /**
+     * The formatted String representing the total context
+     * (the combination of the parent context and this
+     * context)
+     */
     protected String formattedContext;
+
+    /**
+     * Child LogContext's of this LogContext (which will be notified
+     * anytime this context changes)
+     */
     private final List<LogContext> childContexts = new CopyOnWriteArrayList<>();
 
     public LogContext(Map<String, String> context)
@@ -108,12 +125,19 @@ public class LogContext
         updateFormattedContext();
     }
 
+    /**
+     * Notify children of changes in this context
+     */
     protected void updateChildren()
     {
         ImmutableMap<String, String> combined = combineMaps(parentContext, context);
         childContexts.forEach((child) -> child.parentContextUpdated(combined));
     }
 
+    /**
+     * Handle a change in the parent's context
+     * @param parentContext the parent's new  context
+     */
     protected void parentContextUpdated(ImmutableMap<String, String> parentContext)
     {
         this.parentContext = parentContext;

--- a/src/main/java/org/jitsi/utils/logging2/LogContext.java
+++ b/src/main/java/org/jitsi/utils/logging2/LogContext.java
@@ -27,7 +27,7 @@ import java.util.stream.*;
 /**
  * Maintains a map of key-value pairs (both Strings) which holds
  * arbitrary context to use as a prefix for log messages.  Sub-contexts
- * can be created and will inherit any context values from their parent
+ * can be created and will inherit any context values from their ancestors'
  * context.
  */
 // Supress warnings about access since this is a library and usages will
@@ -52,7 +52,7 @@ public class LogContext
 
     /**
      * The formatted String representing the total context
-     * (the combination of the parent context and this
+     * (the combination of the ancestors' context and this
      * context)
      */
     protected String formattedContext;
@@ -83,10 +83,8 @@ public class LogContext
 
     public synchronized LogContext createSubContext(Map<String, String> childContextData)
     {
-        // The parent context to the child being created is the context of all of its ancestors: which includes
-        // this context (its parent) and all of this context's parent context
-        ImmutableMap<String, String> combinedParentContext = combineMaps(ancestorsContext, context);
-        LogContext child = new LogContext(childContextData, combinedParentContext);
+        ImmutableMap<String, String> childAncestorContext = combineMaps(ancestorsContext, context);
+        LogContext child = new LogContext(childContextData, childAncestorContext);
         childContexts.add(new WeakReference<>(child));
         return child;
     }
@@ -113,7 +111,7 @@ public class LogContext
             LogContext c = iter.next().get();
             if (c != null)
             {
-                c.parentContextUpdated(combined);
+                c.ancestorContextUpdated(combined);
             }
             else
             {
@@ -123,12 +121,12 @@ public class LogContext
     }
 
     /**
-     * Handle a change in the parent's context
-     * @param parentContext the parent's new  context
+     * Handle a change in the ancestors' context
+     * @param newAncestorContext the ancestors' new  context
      */
-    protected synchronized void parentContextUpdated(ImmutableMap<String, String> parentContext)
+    protected synchronized void ancestorContextUpdated(ImmutableMap<String, String> newAncestorContext)
     {
-        this.ancestorsContext = parentContext;
+        this.ancestorsContext = newAncestorContext;
         updateFormattedContext();
     }
 

--- a/src/main/java/org/jitsi/utils/logging2/LogContext.java
+++ b/src/main/java/org/jitsi/utils/logging2/LogContext.java
@@ -77,8 +77,9 @@ public class LogContext
 
     protected synchronized void updateFormattedContext()
     {
-        this.formattedContext = formatContext(combineMaps(ancestorsContext, context));
-        updateChildren();
+        ImmutableMap<String, String> combined = combineMaps(ancestorsContext, context);
+        this.formattedContext = formatContext(combined);
+        updateChildren(combined);
     }
 
     public synchronized LogContext createSubContext(Map<String, String> childContextData)
@@ -103,15 +104,14 @@ public class LogContext
     /**
      * Notify children of changes in this context
      */
-    protected synchronized void updateChildren()
+    protected synchronized void updateChildren(ImmutableMap<String, String> newAncestorContext)
     {
-        ImmutableMap<String, String> combined = combineMaps(ancestorsContext, context);
         Iterator<WeakReference<LogContext>> iter = childContexts.iterator();
         while (iter.hasNext()) {
             LogContext c = iter.next().get();
             if (c != null)
             {
-                c.ancestorContextUpdated(combined);
+                c.ancestorContextUpdated(newAncestorContext);
             }
             else
             {

--- a/src/main/java/org/jitsi/utils/logging2/LogContext.java
+++ b/src/main/java/org/jitsi/utils/logging2/LogContext.java
@@ -60,7 +60,7 @@ public class LogContext
      * Child LogContext's of this LogContext (which will be notified
      * anytime this context changes)
      */
-    private final List<LogContext> childContexts = new CopyOnWriteArrayList<>();
+    private final List<LogContext> childContexts = new ArrayList<>();
 
     public LogContext(Map<String, String> context)
     {
@@ -74,13 +74,13 @@ public class LogContext
         updateFormattedContext();
     }
 
-    protected void updateFormattedContext()
+    protected synchronized void updateFormattedContext()
     {
         this.formattedContext = formatContext(combineMaps(parentContext, context));
         updateChildren();
     }
 
-    public LogContext createSubContext(Map<String, String> childContextData)
+    public synchronized LogContext createSubContext(Map<String, String> childContextData)
     {
         // The parent context to this child is the combination of this LogContext's context
         // and its parent's context
@@ -95,7 +95,7 @@ public class LogContext
         addContext(JMap.of(key, value));
     }
 
-    public void addContext(Map<String, String> addedContext)
+    public synchronized void addContext(Map<String, String> addedContext)
     {
         this.context = combineMaps(context, addedContext);
         updateFormattedContext();
@@ -104,7 +104,7 @@ public class LogContext
     /**
      * Notify children of changes in this context
      */
-    protected void updateChildren()
+    protected synchronized void updateChildren()
     {
         ImmutableMap<String, String> combined = combineMaps(parentContext, context);
         childContexts.forEach((child) -> child.parentContextUpdated(combined));
@@ -114,7 +114,7 @@ public class LogContext
      * Handle a change in the parent's context
      * @param parentContext the parent's new  context
      */
-    protected void parentContextUpdated(ImmutableMap<String, String> parentContext)
+    protected synchronized void parentContextUpdated(ImmutableMap<String, String> parentContext)
     {
         this.parentContext = parentContext;
         updateFormattedContext();

--- a/src/main/java/org/jitsi/utils/logging2/LogContext.java
+++ b/src/main/java/org/jitsi/utils/logging2/LogContext.java
@@ -122,7 +122,7 @@ public class LogContext
 
     /**
      * Handle a change in the ancestors' context
-     * @param newAncestorContext the ancestors' new  context
+     * @param newAncestorContext the ancestors' new context
      */
     protected synchronized void ancestorContextUpdated(ImmutableMap<String, String> newAncestorContext)
     {

--- a/src/main/java/org/jitsi/utils/logging2/LogContext.java
+++ b/src/main/java/org/jitsi/utils/logging2/LogContext.java
@@ -80,30 +80,6 @@ public class LogContext
         updateChildren();
     }
 
-    @SafeVarargs
-    protected static String formatContext(Map<String, String>... contexts)
-    {
-        StringBuilder contextString = new StringBuilder();
-        for (Map<String, String> context : contexts)
-        {
-            String data = context.entrySet()
-                    .stream()
-                    .map(e -> e.getKey() + "=" + e.getValue())
-                    .collect(Collectors.joining(" "));
-            contextString.append(data);
-        }
-        if (contextString.length() > 0)
-        {
-            return CONTEXT_START_TOKEN +
-                    contextString +
-                    CONTEXT_END_TOKEN;
-        }
-        else
-        {
-            return "";
-        }
-    }
-
     public LogContext createSubContext(Map<String, String> childContextData)
     {
         // The parent context to this child is the combination of this LogContext's context
@@ -144,6 +120,12 @@ public class LogContext
         updateFormattedContext();
     }
 
+    @Override
+    public String toString()
+    {
+        return formattedContext;
+    }
+
     /**
      * Combine all the given maps into a new map.  Note that the order in which the maps
      * are passed matters: keys in later maps will override duplicates in earlier maps.
@@ -162,9 +144,27 @@ public class LogContext
         return ImmutableMap.copyOf(combinedMap);
     }
 
-    @Override
-    public String toString()
+    @SafeVarargs
+    protected static String formatContext(Map<String, String>... contexts)
     {
-        return formattedContext;
+        StringBuilder contextString = new StringBuilder();
+        for (Map<String, String> context : contexts)
+        {
+            String data = context.entrySet()
+                    .stream()
+                    .map(e -> e.getKey() + "=" + e.getValue())
+                    .collect(Collectors.joining(" "));
+            contextString.append(data);
+        }
+        if (contextString.length() > 0)
+        {
+            return CONTEXT_START_TOKEN +
+                    contextString +
+                    CONTEXT_END_TOKEN;
+        }
+        else
+        {
+            return "";
+        }
     }
 }

--- a/src/main/java/org/jitsi/utils/logging2/LogContext.java
+++ b/src/main/java/org/jitsi/utils/logging2/LogContext.java
@@ -30,7 +30,7 @@ import java.util.stream.*;
  * can be created and will inherit any context values from their parent
  * context.
  */
-// Supress warnings about access since this is an library and usages will
+// Supress warnings about access since this is a library and usages will
 // occur outside this repo
 @SuppressWarnings("WeakerAccess")
 public class LogContext

--- a/src/test/java/org/jitsi/utils/logging2/LogContextTest.java
+++ b/src/test/java/org/jitsi/utils/logging2/LogContextTest.java
@@ -88,4 +88,43 @@ public class LogContextTest
         assertTrue(containsData(data, "epId=456"));
         assertTrue(containsData(data, "confId=111"));
     }
+
+    @Test
+    public void addingContextAfterCreation()
+    {
+        LogContext ctx = new LogContext(
+                JMap.ofEntries(
+                        entry("confId", "111"),
+                        entry("epId", "123")
+                )
+        );
+
+        ctx.addContext("newKey", "newValue");
+        String[] data = getTokens(ctx.toString());
+        assertTrue(containsData(data, "confId=111"));
+        assertTrue(containsData(data, "epId=123"));
+        assertTrue(containsData(data, "newKey=newValue"));
+    }
+
+    @Test
+    public void addContextAfterCreationReflectedInChildren()
+    {
+        LogContext ctx = new LogContext(JMap.of("confId", "111"));
+        LogContext subCtx = ctx.createSubContext(JMap.of("epId", "123"));
+        LogContext subSubCtx = subCtx.createSubContext(JMap.of("ssrc", "98765"));
+
+        ctx.addContext("newKey", "newValue");
+
+        String[] subCtxData = getTokens(subCtx.toString());
+        assertTrue(containsData(subCtxData, "confId=111"));
+        assertTrue(containsData(subCtxData, "newKey=newValue"));
+        assertTrue(containsData(subCtxData, "epId=123"));
+
+        String[] subSubCtxData = getTokens(subSubCtx.toString());
+        assertTrue(containsData(subSubCtxData, "confId=111"));
+        assertTrue(containsData(subSubCtxData, "newKey=newValue"));
+        assertTrue(containsData(subSubCtxData, "epId=123"));
+        assertTrue(containsData(subSubCtxData, "ssrc=98765"));
+    }
+
 }

--- a/src/test/java/org/jitsi/utils/logging2/LoggerImplTest.java
+++ b/src/test/java/org/jitsi/utils/logging2/LoggerImplTest.java
@@ -189,7 +189,7 @@ class FakeLogger extends java.util.logging.Logger
 {
     final List<LogRecord> logLines = new ArrayList<>();
 
-    public FakeLogger(String name)
+    FakeLogger(String name)
     {
         super(name, null);
     }
@@ -215,25 +215,13 @@ class FakeLogger extends java.util.logging.Logger
         return last().getMessage();
     }
 
-    String lastContext()
+    private String lastContext()
     {
         return ((ContextLogRecord)last()).getContext();
     }
 
-    public void reset()
+    void reset()
     {
         logLines.clear();
-    }
-
-    class LogLine
-    {
-        final Level level;
-        final String msg;
-
-        LogLine(Level level, String msg)
-        {
-            this.level = level;
-            this.msg = msg;
-        }
     }
 }


### PR DESCRIPTION
There's an interaction in jvb with ice4j where we need this, and although it's possible that we may be able to work around not having it some other way, I did find in a couple places when updating the logger that it would be useful, so thought I would give it a try.

The last commit in this PR tweaks the implementation to enforce the use of immutable maps (really annoying Java doesn't expose that type)--but I had to bring in a guava to do so.  I really wanted to enforce this so we don't have to worry about any concurrency issues, so I thought it was worth it (and, to be honest, I've run into many scenarios where guava had a class I could've used); but we can discuss.