### PR TITLE
add 'transformedBy' helper to config property builder

### DIFF
--- a/jitsi-utils-kotlin/src/main/kotlin/org/jitsi/utils/config/dsl/ConfigPropertyDsl.kt
+++ b/jitsi-utils-kotlin/src/main/kotlin/org/jitsi/utils/config/dsl/ConfigPropertyDsl.kt
@@ -44,9 +44,7 @@ class ConfigPropertyBuilder<T : Any>(
     var innerRetriever: RetrievedTypeHelper<*, T>? = null
 
     inline fun <reified U : Any> retrievedAs(): RetrievedTypeHelper<U, T> {
-        if (innerRetriever != null) {
-            throw Exception("Cannot use both 'retrievedAs' and 'transformedBy")
-        }
+        check(innerRetriever == null) { "Cannot use both 'retrievedAs' and 'transformedBy"}
         return RetrievedTypeHelper<U, T>(U::class).also { innerRetriever = it }
     }
 
@@ -57,9 +55,7 @@ class ConfigPropertyBuilder<T : Any>(
      * 'convertedBy' ourselves with the given function
      */
     fun transformedBy(transformer: (T) -> T) {
-        if (innerRetriever != null) {
-            throw Exception("Cannot use both 'retrievedAs' and 'transformedBy")
-        }
+        check(innerRetriever == null) { "Cannot use both 'retrievedAs' and 'transformedBy"}
         innerRetriever = (RetrievedTypeHelper<T, T>(type)).apply {
             convertedBy(transformer)
         }

--- a/jitsi-utils-kotlin/src/main/kotlin/org/jitsi/utils/config/dsl/ConfigPropertyDsl.kt
+++ b/jitsi-utils-kotlin/src/main/kotlin/org/jitsi/utils/config/dsl/ConfigPropertyDsl.kt
@@ -60,9 +60,9 @@ class ConfigPropertyBuilder<T : Any>(
         if (innerRetriever != null) {
             throw Exception("Cannot use both 'retrievedAs' and 'transformedBy")
         }
-        val helper = RetrievedTypeHelper<T, T>(type)
-        helper convertedBy transformer
-        innerRetriever = helper
+        innerRetriever = (RetrievedTypeHelper<T, T>(type)).apply {
+            convertedBy(transformer)
+        }
     }
 
     fun buildProp(): ConfigProperty<T> {

--- a/jitsi-utils-kotlin/src/test/kotlin/org/jitsi/utils/config/strategy/ConfigPropertyTest.kt
+++ b/jitsi-utils-kotlin/src/test/kotlin/org/jitsi/utils/config/strategy/ConfigPropertyTest.kt
@@ -140,7 +140,7 @@ class ConfigPropertyTest : ShouldSpec() {
             }
         }
         "Using both retrievedAs and transformedBy" {
-            shouldThrow<Exception> {
+            shouldThrow<IllegalStateException> {
                 property<Long> {
                     name("newPropLong")
                     readEveryTime()


### PR DESCRIPTION
Sometimes we want to transform a property's parsed value without converting its type (like we do when calling `retrievedAs<...> convertedBy { ... }`.  For example, if a boolean property used to be named `enable_XXX` but we want to rename it to `disable_XXX` in the new config, when we parse from the old config we need to invert the value.  I ran into this use case when porting JVB config properties.