### PR TITLE
move passwordutil, debugPrintSystemProperties and masks to jitsi-utils

### DIFF
--- a/jitsi-utils/src/main/java/org/jitsi/utils/ConfigUtils.java
+++ b/jitsi-utils/src/main/java/org/jitsi/utils/ConfigUtils.java
@@ -18,6 +18,8 @@ package org.jitsi.utils;
 import org.jitsi.service.configuration.*;
 
 import java.io.*;
+import java.util.*;
+import java.util.regex.*;
 
 /**
  * @author George Politis
@@ -254,5 +256,67 @@ public class ConfigUtils
             ret = getString(cfg, propertyAlternative, defaultValue);
         }
         return ret;
+    }
+
+    /**
+     * Specify names of command line arguments which are password, so that their
+     * values will be masked when 'sun.java.command' is printed to the logs.
+     * Separate each name with a comma.
+     */
+    public static String PASSWORD_CMD_LINE_ARGS;
+
+    /**
+     * Set this filed value to a regular expression which will be used to select
+     * system properties keys whose values should be masked when printed out to
+     * the logs.
+     */
+    public static String PASSWORD_SYS_PROPS;
+
+    /**
+     * Goes over all system properties and outputs their names and values for
+     * debug purposes. The method has no effect if the logger is at a log level
+     * other than DEBUG or TRACE (FINE or FINEST).
+     * * Changed that system properties are printed in INFO level and this way
+     *   they are included in the beginning of every users log file.
+     */
+    public static String debugPrintSystemProperties()
+    {
+        StringBuilder str = new StringBuilder();
+        try
+        {
+            // Password system properties
+            Pattern exclusion = null;
+            if (PASSWORD_SYS_PROPS != null)
+            {
+                exclusion = Pattern.compile(
+                    PASSWORD_SYS_PROPS, Pattern.CASE_INSENSITIVE);
+            }
+            // Password command line arguments
+            String[] passwordArgs = null;
+            if (PASSWORD_CMD_LINE_ARGS != null)
+                passwordArgs = PASSWORD_CMD_LINE_ARGS.split(",");
+
+            for (Map.Entry<Object,Object> e : System.getProperties().entrySet())
+            {
+                String key = String.valueOf(e.getKey());
+                String value = String.valueOf(e.getValue());
+                // Check if this key value should be masked
+                if (exclusion != null && exclusion.matcher(key).find())
+                {
+                    value = "**********";
+                }
+                // Mask command line arguments
+                if (passwordArgs != null && "sun.java.command".equals(key))
+                {
+                    value = PasswordUtil.replacePasswords(value, passwordArgs);
+                }
+                str.append(key).append("=").append(value).append("\n");
+            }
+        }
+        catch (RuntimeException e)
+        {
+            str.append("An exception occurred while writing debug info").append(e.toString());
+        }
+        return str.toString();
     }
 }

--- a/jitsi-utils/src/main/java/org/jitsi/utils/ConfigUtils.java
+++ b/jitsi-utils/src/main/java/org/jitsi/utils/ConfigUtils.java
@@ -273,13 +273,10 @@ public class ConfigUtils
     public static String PASSWORD_SYS_PROPS;
 
     /**
-     * Goes over all system properties and outputs their names and values for
-     * debug purposes. The method has no effect if the logger is at a log level
-     * other than DEBUG or TRACE (FINE or FINEST).
-     * * Changed that system properties are printed in INFO level and this way
-     *   they are included in the beginning of every users log file.
+     * Goes over all system properties and builds a string of their names and
+     * values for debug purposes.
      */
-    public static String debugPrintSystemProperties()
+    public static String getSystemPropertiesDebugString()
     {
         StringBuilder str = new StringBuilder();
         try

--- a/jitsi-utils/src/main/java/org/jitsi/utils/PasswordUtil.java
+++ b/jitsi-utils/src/main/java/org/jitsi/utils/PasswordUtil.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.utils;
+
+/**
+ * The utility class which can be used to clear passwords values from
+ * 'sun.java.command' system property.
+ *
+ * @author Pawel Domas
+ */
+public class PasswordUtil
+{
+    /**
+     * The method will replace password argument values with 'X' in a string
+     * which represents command line arguments(arg=value arg2=value4).
+     *
+     * @param cmdLine a string which represent command line arguments in a form
+     *                where each argument is separated by space and value is
+     *                assigned by '=' sign. For example "arg=value -arg2=value4
+     *                --arg3=val45".
+     * @param passwordArg the name of password argument to be shadowed.
+     *
+     * @return <tt>cmdLine</tt> string with password argument values shadowed by
+     *         'X'
+     */
+    public static String replacePassword(String cmdLine, String passwordArg)
+    {
+        int passwordIdx = cmdLine.indexOf(passwordArg+"=");
+        if (passwordIdx != -1)
+        {
+            // Get arg=pass
+            int argEndIdx = cmdLine.indexOf(" ", passwordIdx);
+            // Check if this is not the last argument
+            if (argEndIdx == -1)
+                argEndIdx = cmdLine.length();
+            String passArg = cmdLine.substring(passwordIdx, argEndIdx);
+
+            // Split to get arg=
+            String strippedPassArg = passArg.substring(0, passArg.indexOf("="));
+
+            // Modify to have arg=X
+            cmdLine = cmdLine.replace(passArg, strippedPassArg + "=X");
+        }
+        return cmdLine;
+    }
+
+    /**
+     * Does {@link #replacePassword(String, String)} for every argument given in
+     * <tt>passwordArgs</tt> array.
+     *
+     * @param string command line argument string, e.g. "arg=3 pass=secret"
+     * @param passwordArgs the array which contains the names of password
+     *                     argument to be shadowed.
+     * @return <tt>cmdLine</tt> string with password arguments values shadowed
+     *         by 'X'
+     */
+    public static String replacePasswords(String string, String[] passwordArgs)
+    {
+        for (String passArg : passwordArgs)
+        {
+            if (StringUtils.isNullOrEmpty(passArg))
+                continue;
+
+            string = replacePassword(string, passArg);
+        }
+        return string;
+    }
+}

--- a/jitsi-utils/src/test/java/org/jitsi/utils/PasswordUtilTest.java
+++ b/jitsi-utils/src/test/java/org/jitsi/utils/PasswordUtilTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.utils;
+
+import org.junit.*;
+import org.junit.runner.*;
+import org.junit.runners.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * Basic test for {@link PasswordUtil} class.
+ *
+ * @author Pawel Domas
+ */
+@RunWith(JUnit4.class)
+public class PasswordUtilTest
+{
+    @Test
+    public void testShadowPassword()
+    {
+        String cmdLine = "AppMain org.jitsi.videobridge.Main" +
+            " --host=example.com --secret3=blablabla --port=5347" +
+            " -secret=pass1 --subdomain=jvb3 --apis=rest,xmpp" +
+            " secret2=23pass4234";
+
+        cmdLine = PasswordUtil.replacePasswords(
+            cmdLine,
+            new String[]{"", "secret3", "secret", "secret2"});
+
+        assertEquals("AppMain org.jitsi.videobridge.Main" +
+                " --host=example.com --secret3=X --port=5347" +
+                " -secret=X --subdomain=jvb3 --apis=rest,xmpp" +
+                " secret2=X",
+            cmdLine);
+    }
+}


### PR DESCRIPTION
Jicoco was accessing `ConfigurationServiceImpl` directly to set the masks so that `debugPrintSystemProperties` masked out the passwords.  Now that the `ConfigurationService` interface is moved to `jitsi-utils`, if we fix this usage then we can break the `jicoco` -> `libjitsi` dependency.  