### PR TITLE
Add Outcome helper

### DIFF
--- a/jitsi-utils-kotlin/src/main/kotlin/org/jitsi/utils/Outcome.kt
+++ b/jitsi-utils-kotlin/src/main/kotlin/org/jitsi/utils/Outcome.kt
@@ -125,4 +125,3 @@ class Outcome {
 
     private inner class Subscriber(val handler: () -> Unit, val outcomeType: OutcomeType)
 }
-

--- a/jitsi-utils-kotlin/src/main/kotlin/org/jitsi/utils/Outcome.kt
+++ b/jitsi-utils-kotlin/src/main/kotlin/org/jitsi/utils/Outcome.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.utils
+
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * [Outcome] models the outcome of some process which is not yet known.  Once
+ * known, it will not change.  It allows subscribing to both the success and
+ * failure of the outcome.  Subscribers are notified once the outcome has
+ * been reached, or instantly if the outcome has already been reached.
+ *
+ * Until an outcome is reached, the state is 'unknown' (it has neither succeeded
+ * nor failed).  This can be tested explicitly with [isKnown].
+ */
+@Suppress("MemberVisibilityCanBePrivate", "unused")
+class Outcome {
+    private val lock = Any()
+    private val subscribers = mutableListOf<Subscriber>()
+    private val succeeded = AtomicReference<Boolean>()
+
+    /**
+     * Mark this [Outcome] as having succeeded.
+     */
+    fun succeeded() {
+        if (succeeded.compareAndSet(null, true)) {
+            synchronized(lock) {
+                subscribers.filter {
+                    it.outcomeType == OutcomeType.SUCCESS
+                }
+                        .forEach { it.handler() }
+            }
+        }
+    }
+
+    /**
+     * Return true if the outcome was successful, false if it failed or if
+     * the outcome is not yet known.
+     */
+    val hasSucceeded: Boolean
+        @JvmName("hasSucceeded") get() = succeeded.get() == true
+
+    /**
+     * Mark this [Outcome] has having failed.
+     */
+    fun failed() {
+        if (succeeded.compareAndSet(null, false)) {
+            synchronized(lock) {
+                subscribers.filter {
+                    it.outcomeType == OutcomeType.FAILURE
+                }
+                        .forEach { it.handler() }
+            }
+        }
+    }
+
+    /**
+     * Return true if the outcome failed, false if it succeeded orr if
+     * the outcome is not yet known.
+     */
+    val hasFailed: Boolean
+        @JvmName("hasFailed") get() = succeeded.get() == false
+
+    /**
+     * Ask to be notified when the outcome has been determined as successful.
+     * [handler] will be invoked immediately if the outcome already succeeded.
+     */
+    fun onSuccess(handler: () -> Unit) {
+        var notifyHandler = false
+        synchronized(lock) {
+            when (succeeded.get()) {
+                true -> notifyHandler = true
+                null -> subscribers.add(Subscriber(handler, OutcomeType.SUCCESS))
+                false -> {}
+            }
+        }
+        if (notifyHandler) {
+            handler()
+        }
+    }
+
+    /**
+     * Ask to be notified when the outcome has been determined as a failure.
+     * [handler] will be invoked immediately if the outcome already failed.
+     */
+    fun onFailure(handler: () -> Unit) {
+        var notifyHandler = false
+        synchronized(lock) {
+            when (succeeded.get()) {
+                false -> notifyHandler = true
+                null -> subscribers.add(Subscriber(handler, OutcomeType.FAILURE))
+                true -> {}
+            }
+        }
+        if (notifyHandler) {
+            handler()
+        }
+    }
+
+    /**
+     * Returns true if the outcome has been reached (success OR failure), false
+     * if it has not yet been reached.
+     */
+    val isKnown: Boolean
+        @JvmName("isKnown") get() = succeeded.get() != null
+
+    private enum class OutcomeType {
+        SUCCESS,
+        FAILURE
+    }
+
+    private inner class Subscriber(val handler: () -> Unit, val outcomeType: OutcomeType)
+}
+

--- a/jitsi-utils-kotlin/src/test/kotlin/org/jitsi/utils/OutcomeTest.kt
+++ b/jitsi-utils-kotlin/src/test/kotlin/org/jitsi/utils/OutcomeTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright @ 2018 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.utils
+
+import io.kotlintest.IsolationMode
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.BehaviorSpec
+
+class OutcomeTest : BehaviorSpec() {
+    override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
+
+//    val outcome = Outcome()
+
+    init {
+        given("an outcome") {
+            val outcome = Outcome()
+            then("the outcome should not yet be known") {
+                outcome.isKnown shouldBe false
+                outcome.hasFailed shouldBe false
+                outcome.hasSucceeded shouldBe false
+            }
+            and("subscribers are added") {
+                var successCalled = false
+                var failCalled = false
+                outcome.onSuccess { successCalled = true }
+                outcome.onFailure { failCalled = true }
+                then("they should not be notified yet") {
+                    successCalled shouldBe false
+                    failCalled shouldBe false
+                }
+                and("the outcome is successful") {
+                    outcome.succeeded()
+                    then("only the success handler should be called") {
+                        successCalled shouldBe true
+                        failCalled shouldBe false
+                    }
+                    and("a success handler is added after") {
+                        var newSuccessCalled = false
+                        outcome.onSuccess { newSuccessCalled = true }
+                        then("it should be called right away") {
+                            newSuccessCalled shouldBe true
+                        }
+                    }
+                }
+                and("the outcome is unsuccessful") {
+                    outcome.failed()
+                    then("only the fail handler should be called") {
+                        successCalled shouldBe false
+                        failCalled shouldBe true
+                    }
+                    and("a failure handler is added after") {
+                        var newFailcalled = false
+                        outcome.onFailure { newFailcalled = true }
+                        then("it should be called right away") {
+                            newFailcalled shouldBe true
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
From the docs: 
```
[Outcome] models the outcome of some process which is not yet known.  Once 
known, it will not change.  It allows subscribing to both the success and
failure of the outcome.  Subscribers are notified once the outcome has
been reached, or instantly if the outcome has already been reached.

Until an outcome is reached, the state is 'unknown' (it has neither succeeded
nor failed).  This can be tested explicitly with [isKnown].
```
I'm playing (yak-shaving) with some stuff around transport in JVB, and found this mechanism really useful for tracking things like ICE state/DTLS handshake state.