### PR TITLE
Prefere native library from java.library.path.

### DIFF
--- a/jitsi-utils/src/main/java/org/jitsi/utils/JNIUtils.java
+++ b/jitsi-utils/src/main/java/org/jitsi/utils/JNIUtils.java
@@ -50,10 +50,10 @@ public final class JNIUtils
     {
         try
         {
-            // Always prefer library from java.library.path over unpacked from jar.
-            // It allows end user to manually unpack native libraries and store them
+            // Always prefer libraries from java.library.path over those unpacked from the jar.
+            // This allows end user to manually unpack native libraries and store them
             // in java.library.path to later load via System.loadLibrary.
-            // This allow end-user to preserve native library on disk,
+            // This allows end-users to preserve native libraries on disk,
             // which is necessary for debuggers like gdb to load symbols.
             System.loadLibrary(libname);
             return;

--- a/jitsi-utils/src/main/java/org/jitsi/utils/JNIUtils.java
+++ b/jitsi-utils/src/main/java/org/jitsi/utils/JNIUtils.java
@@ -50,12 +50,24 @@ public final class JNIUtils
     {
         try
         {
+            // Always prefer library from java.library.path over unpacked from jar.
+            // It allows end user to manually unpack native libraries and store them
+            // in java.library.path to later load via System.loadLibrary.
+            // This allow end-user to preserve native library on disk,
+            // which is necessary for debuggers like gdb to load symbols.
+            System.loadLibrary(libname);
+            return;
+        }
+        catch (UnsatisfiedLinkError e)
+        {
             if (clazz == null)
             {
-                System.loadLibrary(libname);
-                return;
+                throw e;
             }
+        }
 
+        try
+        {
             loadNativeInClassloader(libname, clazz, false);
         }
         catch (UnsatisfiedLinkError ulerr)

--- a/jitsi-utils/src/main/java/org/jitsi/utils/JNIUtils.java
+++ b/jitsi-utils/src/main/java/org/jitsi/utils/JNIUtils.java
@@ -61,11 +61,11 @@ public final class JNIUtils
             }
             catch (UnsatisfiedLinkError e)
             {
-                if (clazz != null)
+                if (clazz == null)
                 {
-                    loadNativeInClassloader(libname, clazz, false);
+                    throw e;
                 }
-                throw e;
+                loadNativeInClassloader(libname, clazz, false);
             }
         }
         catch (UnsatisfiedLinkError ulerr)

--- a/jitsi-utils/src/main/java/org/jitsi/utils/JNIUtils.java
+++ b/jitsi-utils/src/main/java/org/jitsi/utils/JNIUtils.java
@@ -60,10 +60,7 @@ public final class JNIUtils
         }
         catch (UnsatisfiedLinkError e)
         {
-            if (clazz == null)
-            {
-                throw e;
-            }
+            // ignore and try loading from other sources
         }
 
         try

--- a/jitsi-utils/src/main/java/org/jitsi/utils/JNIUtils.java
+++ b/jitsi-utils/src/main/java/org/jitsi/utils/JNIUtils.java
@@ -58,6 +58,7 @@ public final class JNIUtils
                 // This allows end-users to preserve native libraries on disk,
                 // which is necessary for debuggers like gdb to load symbols.
                 System.loadLibrary(libname);
+                return;
             }
             catch (UnsatisfiedLinkError e)
             {
@@ -65,8 +66,8 @@ public final class JNIUtils
                 {
                     throw e;
                 }
-                loadNativeInClassloader(libname, clazz, false);
             }
+            loadNativeInClassloader(libname, clazz, false);
         }
         catch (UnsatisfiedLinkError ulerr)
         {

--- a/jitsi-utils/src/main/java/org/jitsi/utils/JNIUtils.java
+++ b/jitsi-utils/src/main/java/org/jitsi/utils/JNIUtils.java
@@ -50,22 +50,23 @@ public final class JNIUtils
     {
         try
         {
-            // Always prefer libraries from java.library.path over those unpacked from the jar.
-            // This allows end user to manually unpack native libraries and store them
-            // in java.library.path to later load via System.loadLibrary.
-            // This allows end-users to preserve native libraries on disk,
-            // which is necessary for debuggers like gdb to load symbols.
-            System.loadLibrary(libname);
-            return;
-        }
-        catch (UnsatisfiedLinkError e)
-        {
-            // ignore and try loading from other sources
-        }
-
-        try
-        {
-            loadNativeInClassloader(libname, clazz, false);
+            try
+            {
+                // Always prefer libraries from java.library.path over those unpacked from the jar.
+                // This allows end user to manually unpack native libraries and store them
+                // in java.library.path to later load via System.loadLibrary.
+                // This allows end-users to preserve native libraries on disk,
+                // which is necessary for debuggers like gdb to load symbols.
+                System.loadLibrary(libname);
+            }
+            catch (UnsatisfiedLinkError e)
+            {
+                if (clazz != null)
+                {
+                    loadNativeInClassloader(libname, clazz, false);
+                }
+                throw e;
+            }
         }
         catch (UnsatisfiedLinkError ulerr)
         {


### PR DESCRIPTION
This PR change the preference of native libraries lookup.

The PR proposes to always try loading native library from `java.library.path`.
This allow end-user to manually extract library from jar without removing it.

Currently when library extracted into `/tmp/jna/...` it removed immediately after being loaded into JVB.
This is very unsuitable for native debugging. 
For example, `gdb` has no idea about deleted file and can not provide relevant debugging information for loaded library.
```
(gdb) info sharedlibrary
From                To                  Syms Read   Shared Object Library
0x00007ffedf8e83f0  0x00007ffedf8f6a38  Yes (*)     /tmp/jna-1356855001/jna3054194125002259017.tmp
```

With this change user can manually unpack library from jar and it will be picked up by `JNIUtils.loadLibrary`. User can preserve library on disk to facilitate debugging.

