### PR TITLE
Code check annotations should not be required by dependencies

### DIFF
--- a/jitsi-utils/pom.xml
+++ b/jitsi-utils/pom.xml
@@ -62,6 +62,7 @@
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
       <version>${spotbugs.version}</version>
+      <optional>true</optional>
     </dependency>
 
     <dependency>

--- a/jitsi-utils/pom.xml
+++ b/jitsi-utils/pom.xml
@@ -41,6 +41,7 @@
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
       <version>15.0</version>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>net.java.dev.jna</groupId>


### PR DESCRIPTION
Follow-up to #44