### PR TITLE
Ensure that PeriodicRunnables' schedule doesn't slip

### DIFF
--- a/jitsi-utils/src/main/java/org/jitsi/utils/concurrent/PeriodicRunnable.java
+++ b/jitsi-utils/src/main/java/org/jitsi/utils/concurrent/PeriodicRunnable.java
@@ -127,6 +127,15 @@ public abstract class PeriodicRunnable
     @Override
     public void run()
     {
-        _lastProcessTime = System.currentTimeMillis();
+        if (_lastProcessTime < 0)
+        {
+            _lastProcessTime = System.currentTimeMillis();
+        }
+        else
+        {
+            /* This ensures the schedule doesn't slip if one run is
+             * scheduled late. */
+            _lastProcessTime += _period;
+        }
     }
 }


### PR DESCRIPTION
if one run is scheduled late.

Otherwise (e.g.) `ProbingDataSender` can end up underfilling the bandwidth it wants to send.