### PR TITLE
make ALL the default min logl level

### DIFF
--- a/src/main/kotlin/org/jitsi/utils/logging2/LoggerExtensions.kt
+++ b/src/main/kotlin/org/jitsi/utils/logging2/LoggerExtensions.kt
@@ -31,7 +31,7 @@ import kotlin.reflect.full.companionObject
  *
  */
 fun <T : Any> T.createLogger(
-    minLogLevel: Level = Level.INFO,
+    minLogLevel: Level = Level.ALL,
     logContext: LogContext = LogContext.EMPTY
 ): Logger = LoggerImpl(getClassForLogging(this.javaClass).name, minLogLevel, logContext)
 


### PR DESCRIPTION
I ran into this today and don't think this default makes any sense: the min log level makes it impossible to set the log level to anything below it, which I don't think is what we want for `createLogger` (it took me a while to figure why I couldn't see my debug log messages when setting the level of a class which uses `createLogger` to `FINE`).

It's possible something is relying on this, but hoping the log checks in jenkins will catch it if so.