### PR TITLE
Fix release with Dokka

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Build and test with Maven
-        run: mvn -B verify -Drelease=true
+        run: mvn -B verify
 
   release:
     if: github.ref == 'refs/heads/master'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -54,6 +54,14 @@ jobs:
           server-username: SONATYPE_USER
           server-password: SONATYPE_PW
 
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       - name: Set version
         run: |
           VERSION=`git describe --match "v[0-9\.]*" --long --dirty --always`

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Build and test with Maven
-        run: mvn -B verify
+        run: mvn -B verify -DperformRelease=true
 
   release:
     if: github.ref == 'refs/heads/master'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Build and test with Maven
-        run: mvn -B verify -DperformRelease=true
+        run: mvn -B verify -Drelease=true
 
   release:
     if: github.ref == 'refs/heads/master'
@@ -78,6 +78,6 @@ jobs:
             --no-transfer-progress \
             --batch-mode \
             -Dgpg.passphrase="${{ secrets.GPG_PW }}" \
-            -DperformRelease=true \
+            -Drelease=true \
             -DskipTests \
             deploy

--- a/pom.xml
+++ b/pom.xml
@@ -287,7 +287,8 @@
                 <configuration>
                     <show>private</show>
                     <nohelp>true</nohelp>
-                    <doclint>-missing</doclint>
+                    <!-- Javadoc doesn't find the Kotlin classes -->
+                    <doclint>none</doclint>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <java.version>1.8</java.version>
         <kotlin.version>1.3.72</kotlin.version>
         <kotest.version>4.1.3</kotest.version>
+        <dokka.version>1.4.10.2</dokka.version>
     </properties>
 
     <dependencies>
@@ -244,19 +245,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <version>4.0.0</version>
@@ -281,14 +269,27 @@
                 </dependencies>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.2.0</version>
+                <groupId>org.jetbrains.dokka</groupId>
+                <artifactId>dokka-maven-plugin</artifactId>
+                <version>${dokka.version}</version>
+                <executions>
+                    <execution>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>dokka</goal>
+                            <goal>javadoc</goal>
+                            <goal>javadocJar</goal>
+                        </goals>
+                    </execution>
+                </executions>
                 <configuration>
-                    <show>private</show>
-                    <nohelp>true</nohelp>
-                    <!-- Javadoc doesn't find the Kotlin classes -->
-                    <doclint>none</doclint>
+                    <dokkaPlugins>
+                        <plugin>
+                            <groupId>org.jetbrains.dokka</groupId>
+                            <artifactId>kotlin-as-java-plugin</artifactId>
+                            <version>${dokka.version}</version>
+                        </plugin>
+                    </dokkaPlugins>
                 </configuration>
             </plugin>
             <plugin>
@@ -315,7 +316,7 @@
             <id>release</id>
             <activation>
                 <property>
-                    <name>performRelease</name>
+                    <name>release</name>
                     <value>true</value>
                 </property>
             </activation>
@@ -345,6 +346,15 @@
             </build>
         </profile>
     </profiles>
+
+    <pluginRepositories>
+        <!-- Required for Dokka -->
+        <pluginRepository>
+            <id>jcenter</id>
+            <name>JCenter</name>
+            <url>https://jcenter.bintray.com/</url>
+        </pluginRepository>
+    </pluginRepositories>
 
     <distributionManagement>
         <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -287,6 +287,7 @@
                 <configuration>
                     <show>private</show>
                     <nohelp>true</nohelp>
+                    <doclint>-missing</doclint>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/org/jitsi/utils/dsi/ActiveSpeakerChangedListener.java
+++ b/src/main/java/org/jitsi/utils/dsi/ActiveSpeakerChangedListener.java
@@ -17,7 +17,7 @@ package org.jitsi.utils.dsi;
 
 /**
  * Implementing classes can be notified about changes to the 'active' stream
- * (identified by its SSRC) using {@link #activeSpeakerChanged(long)}.
+ * (identified by its SSRC) using {@link #activeSpeakerChanged(Object)}.
  *
  * @author Boris Grozev
  */

--- a/src/main/java/org/jitsi/utils/dsi/ActiveSpeakerDetector.java
+++ b/src/main/java/org/jitsi/utils/dsi/ActiveSpeakerDetector.java
@@ -23,7 +23,7 @@ package org.jitsi.utils.dsi;
  * Implementations of <tt>ActiveSpeakerDetector</tt> get notified about the
  * (current) audio levels of multiple audio streams (identified by their
  * synchronization source identifiers/SSRCs) via calls to
- * {@link #levelChanged(long, int)} and determine/identify which stream is
+ * {@link #levelChanged(Object, int)} and determine/identify which stream is
  * dominant/active (in terms of speech). When the active stream changes,
  * listeners registered via
  * {@link #addActiveSpeakerChangedListener(ActiveSpeakerChangedListener)} are

--- a/src/main/java/org/jitsi/utils/queue/AsyncQueueHandler.java
+++ b/src/main/java/org/jitsi/utils/queue/AsyncQueueHandler.java
@@ -57,13 +57,13 @@ final class AsyncQueueHandler<T>
     private final ExecutorService executor;
 
     /**
-     * An {@link BlockingQueue <T>} whose items read on separate thread and
+     * An {@link BlockingQueue} whose items read on separate thread and
      * processed by provided {@link #handler}.
      */
     private final BlockingQueue<T> queue;
 
     /**
-     * The {@link Handler<T>} used to handle items read from
+     * The {@link Handler} used to handle items read from
      * {@link #queue} by {@link #reader}.
      */
     private final Handler<T> handler;
@@ -77,7 +77,7 @@ final class AsyncQueueHandler<T>
      * Specifies the number of items allowed to be handled sequentially
      * without yielding control to executor's thread. Specifying positive
      * number allows implementation of cooperative multi-tasking
-     * between different {@link AsyncQueueHandler<T>} sharing
+     * between different {@link AsyncQueueHandler} sharing
      * same {@link ExecutorService}.
      */
     private final long maxSequentiallyHandledItems;
@@ -149,7 +149,7 @@ final class AsyncQueueHandler<T>
     };
 
     /**
-     * Constructs instance of {@link AsyncQueueHandler<T>} which is capable of
+     * Constructs instance of {@link AsyncQueueHandler} which is capable of
      * asynchronous reading provided queue from thread borrowed from executor to
      * process items with provided handler.
      * @param queue thread-safe queue which holds items to process
@@ -168,7 +168,7 @@ final class AsyncQueueHandler<T>
     }
 
     /**
-     * Constructs instance of {@link AsyncQueueHandler<T>} which is capable of
+     * Constructs instance of {@link AsyncQueueHandler} which is capable of
      * asynchronous reading provided queue from thread borrowed from executor to
      * process items with provided handler.
      * @param queue thread-safe queue which holds items to process

--- a/src/main/java/org/jitsi/utils/queue/PacketQueue.java
+++ b/src/main/java/org/jitsi/utils/queue/PacketQueue.java
@@ -539,8 +539,8 @@ public abstract class PacketQueue<T>
     }
 
     /**
-     * An adapter class implementing {@link AsyncQueueHandler.Handler<T>}
-     * to wrap {@link PacketHandler<T>}.
+     * An adapter class implementing {@link AsyncQueueHandler.Handler}
+     * to wrap {@link PacketHandler}.
      */
     private final class HandlerAdapter implements AsyncQueueHandler.Handler<T>
     {
@@ -550,8 +550,8 @@ public abstract class PacketQueue<T>
         private final PacketHandler<T> handler;
 
         /**
-         * Constructs adapter of {@link PacketHandler<T>} to
-         * {@link AsyncQueueHandler.Handler<T>} interface.
+         * Constructs adapter of {@link PacketHandler} to
+         * {@link AsyncQueueHandler.Handler} interface.
          * @param handler an handler instance to adapt
          */
         HandlerAdapter(PacketHandler<T> handler)

--- a/src/main/java/org/jitsi/utils/queue/QueueStatistics.java
+++ b/src/main/java/org/jitsi/utils/queue/QueueStatistics.java
@@ -73,9 +73,6 @@ public class QueueStatistics
 
     /**
      * Initializes a new {@link QueueStatistics} instance.
-     * 
-     * @param id Identifier to distinguish the log output of multiple
-     *            {@link QueueStatistics} instances.
      */
     public QueueStatistics()
     {


### PR DESCRIPTION
Follow-up to #75. Javadoc does not work on Java 11 with Kotlin, instead use Dokka to also publish Kotlin documention.

Note that the `<pluginRepositories>` tag in the pom is really annoying, this shouldn't be in a pom published to Maven Central. Remove it once kotlin/dokka#41 is fixed. Plus, connections to JCenter/Bintray are unstable, which might cause shaky builds (but only if the pom changed, otherwise the cache kicks in).