### PR TITLE
Allow manipulation of logger delegate handlers

### DIFF
--- a/src/main/java/org/jitsi/utils/logging2/Logger.java
+++ b/src/main/java/org/jitsi/utils/logging2/Logger.java
@@ -38,6 +38,14 @@ public interface Logger
      * @return the created logger
      */
     Logger createChildLogger(String name);
+
+    /**
+     * Override any existing handlers for this logger (including any parent handlers)
+     * and use the given one
+     * @param handler the handler to use
+     */
+    void useHandler(Handler handler);
+
     /**
      * Check if a message with a TRACE level would actually be logged by this
      * logger.

--- a/src/main/java/org/jitsi/utils/logging2/Logger.java
+++ b/src/main/java/org/jitsi/utils/logging2/Logger.java
@@ -40,11 +40,19 @@ public interface Logger
     Logger createChildLogger(String name);
 
     /**
-     * Override any existing handlers for this logger (including any parent handlers)
-     * and use the given one
-     * @param handler the handler to use
+     * See {@link java.util.logging.Logger#setUseParentHandlers(boolean)}
      */
-    void useHandler(Handler handler);
+    void setUseParentHandlers(boolean useParentHandlers);
+
+    /**
+     * See {@link java.util.logging.Logger#addHandler(Handler)}
+     */
+    void addHandler(Handler handler) throws SecurityException;
+
+    /**
+     * See {@link java.util.logging.Logger#removeHandler(Handler)}
+     */
+    void removeHandler(Handler handler) throws SecurityException;
 
     /**
      * Check if a message with a TRACE level would actually be logged by this

--- a/src/main/java/org/jitsi/utils/logging2/LoggerImpl.java
+++ b/src/main/java/org/jitsi/utils/logging2/LoggerImpl.java
@@ -84,12 +84,23 @@ public class LoggerImpl implements Logger
     }
 
     @Override
-    public void useHandler(Handler handler)
+    public void setUseParentHandlers(boolean useParentHandlers)
     {
         loggerDelegate.setUseParentHandlers(false);
+    }
+
+    @Override
+    public void addHandler(Handler handler) throws SecurityException
+    {
         loggerDelegate.addHandler(handler);
     }
 
+    @Override
+    public void removeHandler(Handler handler) throws SecurityException
+    {
+        loggerDelegate.removeHandler(handler);
+    }
+    
     private boolean isLoggable(Level level)
     {
         return level.intValue() >= minLogLevel.intValue() && loggerDelegate.isLoggable(level);

--- a/src/main/java/org/jitsi/utils/logging2/LoggerImpl.java
+++ b/src/main/java/org/jitsi/utils/logging2/LoggerImpl.java
@@ -83,6 +83,13 @@ public class LoggerImpl implements Logger
         return new LoggerImpl(name, minLogLevel, this.logContext.createSubContext(Collections.emptyMap()));
     }
 
+    @Override
+    public void useHandler(Handler handler)
+    {
+        loggerDelegate.setUseParentHandlers(false);
+        loggerDelegate.addHandler(handler);
+    }
+
     private boolean isLoggable(Level level)
     {
         return level.intValue() >= minLogLevel.intValue() && loggerDelegate.isLoggable(level);

--- a/src/test/java/org/jitsi/utils/logging2/LoggerImplTest.java
+++ b/src/test/java/org/jitsi/utils/logging2/LoggerImplTest.java
@@ -186,6 +186,40 @@ public class LoggerImplTest
         logger.info(() -> "hello, world!");
         assertEquals(1, fakeLogger.logLines.size());
     }
+
+    @Test
+    public void testHandler()
+    {
+        // We want to use a real logger for this test
+        LoggerImpl.loggerFactory = oldLoggerFactoryFunction;
+
+        LoggerImpl logger = new LoggerImpl("test");
+        FakeHandler handler = new FakeHandler();
+        logger.useHandler(handler);
+
+        logger.info("hello, world!");
+
+        assertEquals(1, handler.logRecords.size());
+        LogRecord record = handler.logRecords.get(0);
+        assertEquals(record.getMessage(), "hello, world!");
+        assertEquals(record.getLoggerName(), "test");
+    }
+}
+
+class FakeHandler extends Handler {
+    final List<LogRecord> logRecords = new ArrayList<>();
+
+    @Override
+    public void publish(LogRecord record)
+    {
+        logRecords.add(record);
+    }
+
+    @Override
+    public void flush() { }
+
+    @Override
+    public void close() throws SecurityException { }
 }
 
 class FakeLogger extends java.util.logging.Logger

--- a/src/test/java/org/jitsi/utils/logging2/LoggerImplTest.java
+++ b/src/test/java/org/jitsi/utils/logging2/LoggerImplTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 public class LoggerImplTest
 {
     private static Function<String, java.util.logging.Logger> oldLoggerFactoryFunction;
-    private FakeLogger fakeLogger = new FakeLogger("fake");
+    private final FakeLogger fakeLogger = new FakeLogger("fake");
 
     @BeforeAll
     public static void beforeClass()

--- a/src/test/java/org/jitsi/utils/logging2/LoggerImplTest.java
+++ b/src/test/java/org/jitsi/utils/logging2/LoggerImplTest.java
@@ -195,7 +195,8 @@ public class LoggerImplTest
 
         LoggerImpl logger = new LoggerImpl("test");
         FakeHandler handler = new FakeHandler();
-        logger.useHandler(handler);
+        logger.setUseParentHandlers(false);
+        logger.addHandler(handler);
 
         logger.info("hello, world!");
 


### PR DESCRIPTION
Jibri doesn't currently use our logger because it needs to override the logging handlers so it can log to different files, so this PR expose  some java.util.logging APIs to be enable that.