### PR TITLE
add getter to check if packet queue stats are enabled

### DIFF
--- a/src/main/java/org/jitsi/utils/queue/PacketQueue.java
+++ b/src/main/java/org/jitsi/utils/queue/PacketQueue.java
@@ -58,6 +58,11 @@ public abstract class PacketQueue<T>
         enableStatisticsDefault = enable;
     }
 
+    public static boolean getEnableStatisticsDefault()
+    {
+        return enableStatisticsDefault;
+    }
+
     /**
      * The underlying {@link BlockingQueue} which holds packets.
      * Used as synchronization object between {@link #close()}, {@link #get()}


### PR DESCRIPTION
This one is a bit tricky, as the only thing we can really check here is if the packet queue stats are enabled _by default_.  However, when we enable packet queue stats via rest, this is what we're changing so I think it makes sense that this is what we query.