### PR TITLE
Logging cleanup

### DIFF
--- a/src/main/java/org/jitsi/utils/DatagramPacketFilter.java
+++ b/src/main/java/org/jitsi/utils/DatagramPacketFilter.java
@@ -21,7 +21,10 @@ import java.net.*;
  * Represents a filter which selects or deselects <tt>DatagramPacket</tt>s.
  *
  * @author Lubomir Marinov
+ * @deprecated Use a Java 8 lambda ({@link java.util.function.Function})
  */
+@Deprecated
+@FunctionalInterface
 public interface DatagramPacketFilter
 {
     /**

--- a/src/main/java/org/jitsi/utils/logging/InstanceLogger.java
+++ b/src/main/java/org/jitsi/utils/logging/InstanceLogger.java
@@ -30,7 +30,7 @@ public class InstanceLogger
     /**
      * The {@link org.jitsi.utils.logging.Logger} used for logging.
      */
-    private org.jitsi.utils.logging.Logger loggingDelegate;
+    private final Logger loggingDelegate;
 
     /**
      * The {@link org.jitsi.utils.logging.Logger} used for configuring the level. Messages are logged
@@ -39,7 +39,7 @@ public class InstanceLogger
      * 2. {@link #loggingDelegate} allows it.
      * 3. {@link #level}, is not set or allows it.
      */
-    private org.jitsi.utils.logging.Logger levelDelegate;
+    private final Logger levelDelegate;
 
     /**
      * The level configured for this instance.

--- a/src/main/java/org/jitsi/utils/logging/Logger.java
+++ b/src/main/java/org/jitsi/utils/logging/Logger.java
@@ -67,7 +67,9 @@ public abstract class Logger
 
     /**
      * Logs an entry in the calling method.
+     * @deprecated Use your own log statement
      */
+    @Deprecated
     public void logEntry()
     {
         if (isLoggable(Level.FINEST))
@@ -79,7 +81,9 @@ public abstract class Logger
 
     /**
      * Logs exiting the calling method
+     * @deprecated Use your own log statement
      */
+    @Deprecated
     public void logExit()
     {
         if (isLoggable(Level.FINEST))

--- a/src/main/java/org/jitsi/utils/queue/AsyncQueueHandler.java
+++ b/src/main/java/org/jitsi/utils/queue/AsyncQueueHandler.java
@@ -40,7 +40,7 @@ final class AsyncQueueHandler<T>
      * {@link AsyncQueueHandler} class and its instances for logging output.
      */
     private static final Logger logger
-        = Logger.getLogger(AsyncQueueHandler.class.getName());
+        = Logger.getLogger(AsyncQueueHandler.class);
 
     /**
      * Executor service to run {@link #reader}, which asynchronously

--- a/src/main/java/org/jitsi/utils/queue/CountingErrorHandler.java
+++ b/src/main/java/org/jitsi/utils/queue/CountingErrorHandler.java
@@ -31,8 +31,7 @@ public class CountingErrorHandler implements ErrorHandler
      * The {@link Logger} used by the {@link PacketQueue} class and its
      * instances for logging output.
      */
-    private static final Logger logger
-            = Logger.getLogger(PacketQueue.class.getName());
+    private static final Logger logger = Logger.getLogger(PacketQueue.class);
 
     /**
      * The number of dropped packets.

--- a/src/main/java/org/jitsi/utils/queue/PacketQueue.java
+++ b/src/main/java/org/jitsi/utils/queue/PacketQueue.java
@@ -37,8 +37,7 @@ public class PacketQueue<T>
      * The {@link Logger} used by the {@link PacketQueue} class and its
      * instances for logging output.
      */
-    private static final Logger logger
-        = Logger.getLogger(PacketQueue.class.getName());
+    private static final Logger logger = Logger.getLogger(PacketQueue.class);
 
     /**
      * The default value for the {@code enableStatistics} constructor argument.


### PR DESCRIPTION
- logEntry/logExit are only used in Jitsi Desktop and will be removed there
- class.getName() is unnecessary
- DatagramPacketFilter is only used once in libjitsi and will be removed there