### PR TITLE
ref(EventEmitter): use error lvl for throwables

### DIFF
--- a/src/main/java/org/jitsi/utils/event/PropertyChangeNotifier.java
+++ b/src/main/java/org/jitsi/utils/event/PropertyChangeNotifier.java
@@ -137,7 +137,7 @@ public class PropertyChangeNotifier
                     }
                     else
                     {
-                        logger.warn(
+                        logger.error(
                                 "A PropertyChangeListener threw an exception"
                                     + " while handling a PropertyChangeEvent.",
                                 t);

--- a/src/main/java/org/jitsi/utils/queue/AsyncQueueHandler.java
+++ b/src/main/java/org/jitsi/utils/queue/AsyncQueueHandler.java
@@ -134,7 +134,7 @@ final class AsyncQueueHandler<T>
                 }
                 catch (Throwable e)
                 {
-                    logger.warn("Failed to handle item: ", e);
+                    logger.error("Failed to handle item: ", e);
                 }
             }
         }

--- a/src/main/java/org/jitsi/utils/queue/CountingErrorHandler.java
+++ b/src/main/java/org/jitsi/utils/queue/CountingErrorHandler.java
@@ -58,7 +58,7 @@ public class CountingErrorHandler implements ErrorHandler
     @Override
     public void packetHandlingFailed(Throwable t)
     {
-        logger.warn("Failed to handle packet: ", t);
+        logger.error("Failed to handle packet: ", t);
         numExceptions.incrementAndGet();
     }
 

--- a/src/main/kotlin/org/jitsi/utils/event/EventEmitter.kt
+++ b/src/main/kotlin/org/jitsi/utils/event/EventEmitter.kt
@@ -48,7 +48,7 @@ sealed class BaseEventEmitter<EventHandlerType>(
         try {
             block()
         } catch (e: Exception) {
-            logger.warn("Exception from event handler: ${e.message}", e)
+            logger.error("Exception from event handler: ${e.message}", e)
         }
     }
 }


### PR DESCRIPTION
Log unhandled exceptions inside event handlers on the error level.
Usually this indicates an unexpected bug and having it on the error
level brings more attention. On the warning level  it gets mixed with
other non-critical messages which are often expected to happen under
normal operating conditions.