### PR TITLE
Don't cancel AsyncQueueHandler's runnable from itself before exiting.

### DIFF
--- a/src/main/java/org/jitsi/utils/queue/AsyncQueueHandler.java
+++ b/src/main/java/org/jitsi/utils/queue/AsyncQueueHandler.java
@@ -124,7 +124,8 @@ final class AsyncQueueHandler<T>
 
                     if (item == null)
                     {
-                        cancel(false);
+                        running = false;
+                        readerFuture = null;
                         return;
                     }
                 }


### PR DESCRIPTION
It's redundant, and a profile showed this cancellation taking 8% of CPU on a loaded JVB.