### PR TITLE
Remove weak references from LogContext childContexts when the child is GC'd

### DIFF
--- a/src/main/kotlin/org/jitsi/utils/logging2/LogContext.kt
+++ b/src/main/kotlin/org/jitsi/utils/logging2/LogContext.kt
@@ -63,6 +63,7 @@ class LogContext private constructor(
         ancestorsContext + context,
         childContextData
     ).also {
+        childContexts.removeIf { r -> r.get() == null }
         childContexts.add(WeakReference(it))
     }
 

--- a/src/main/kotlin/org/jitsi/utils/logging2/LogContext.kt
+++ b/src/main/kotlin/org/jitsi/utils/logging2/LogContext.kt
@@ -59,18 +59,18 @@ class LogContext private constructor(
     /** Child [LogContext]s of this [LogContext] (which will be notified anytime this context changes) */
     private val childContexts = mutableMapOf<Long, WeakReference<LogContext>>()
 
-    private var childCounter = 0L
+    private var nextKey = 0L
 
     @Synchronized
     fun createSubContext(childContextData: Map<String, String>) = LogContext(
         ancestorsContext + context,
         childContextData
     ).also {
-        val count = childCounter++
-        childContexts[count] = WeakReference(it)
+        val key = nextKey++
+        childContexts[key] = WeakReference(it)
         CLEANER.register(it) {
             synchronized(this@LogContext) {
-                childContexts.remove(count)
+                childContexts.remove(key)
             }
         }
     }


### PR DESCRIPTION
Should prevent unbounded growth of the context array for contexts with lots of short-lived children.