### PR TITLE
fix: Pass useParentHandlers argument in LoggerImpl.setUseParentHandlers

### DIFF
--- a/src/main/java/org/jitsi/utils/logging2/LoggerImpl.java
+++ b/src/main/java/org/jitsi/utils/logging2/LoggerImpl.java
@@ -86,7 +86,7 @@ public class LoggerImpl implements Logger
     @Override
     public void setUseParentHandlers(boolean useParentHandlers)
     {
-        loggerDelegate.setUseParentHandlers(false);
+        loggerDelegate.setUseParentHandlers(useParentHandlers);
     }
 
     @Override


### PR DESCRIPTION
`LoggerImpl.setUseParentHandlers` ignored its argument and always passed `false` to the delegate, silently breaking any caller that passed `true`.