### PR TITLE
RateLimit: separate checking a request from recording it

### DIFF
--- a/src/main/kotlin/org/jitsi/utils/RateLimit.kt
+++ b/src/main/kotlin/org/jitsi/utils/RateLimit.kt
@@ -40,29 +40,50 @@ class RateLimit(
     /** Stores the timestamps of requests that have been received. */
     private val requests: Deque<Instant> = LinkedList()
 
-    /** Return true if the request should be accepted and false otherwise.
+    /**
+     * Return true if a request at [now] would be accepted, without recording it. Use this together with [record]
+     * when a request has to pass more than one [RateLimit], so that a request rejected by one limit does not
+     * count against the others.
      * [now] is the current time, if not provided [clock].instant() is used.
-     * [minInterval] can be specified per [accept] call to support varying minimum intervals
-     *  (e.g., based on round-trip times).
-     *  */
+     * [minInterval] can be specified per call to support varying minimum intervals (e.g., based on round-trip
+     * times).
+     */
     @JvmOverloads
-    fun accept(now: Instant = clock.instant(), minInterval: Duration = defaultMinInterval): Boolean {
-        val previousRequest = requests.peekLast()
-        if (previousRequest == null) {
-            requests.add(now)
-            return true
-        }
+    fun wouldAccept(now: Instant = clock.instant(), minInterval: Duration = defaultMinInterval): Boolean {
+        val previousRequest = requests.peekLast() ?: return true
 
         if (Duration.between(previousRequest, now) < minInterval) {
             return false
         }
 
         // Allow only [maxRequests] requests within the last [interval]
+        return requests.count { Duration.between(it, now) <= interval } < maxRequests
+    }
+
+    /**
+     * Record that a request was made at [now], so that it counts towards subsequent [wouldAccept] and [accept]
+     * calls. This does not check whether the request would have been accepted; call [wouldAccept] first.
+     * [now] is the current time, if not provided [clock].instant() is used.
+     */
+    @JvmOverloads
+    fun record(now: Instant = clock.instant()) {
         requests.removeIf { Duration.between(it, now) > interval }
-        if (requests.size >= maxRequests) {
+        requests.add(now)
+    }
+
+    /**
+     * Return true if the request should be accepted and false otherwise. An accepted request is recorded, a
+     * rejected one is not. Equivalent to [wouldAccept] followed by [record] when it returns true.
+     * [now] is the current time, if not provided [clock].instant() is used.
+     * [minInterval] can be specified per [accept] call to support varying minimum intervals
+     *  (e.g., based on round-trip times).
+     */
+    @JvmOverloads
+    fun accept(now: Instant = clock.instant(), minInterval: Duration = defaultMinInterval): Boolean {
+        if (!wouldAccept(now, minInterval)) {
             return false
         }
-        requests.add(now)
+        record(now)
         return true
     }
 }

--- a/src/test/kotlin/org/jitsi/utils/RateLimitTest.kt
+++ b/src/test/kotlin/org/jitsi/utils/RateLimitTest.kt
@@ -153,5 +153,60 @@ class RateLimitTest : ShouldSpec() {
                 rateLimit.accept() shouldBe true
             }
         }
+
+        context("Checking without recording") {
+            val clock = FakeClock()
+            val rateLimit = RateLimit(
+                clock = clock,
+                defaultMinInterval = 10.ms,
+                maxRequests = 2,
+                interval = 100.ms
+            )
+            should("allow the 1st request") {
+                rateLimit.wouldAccept() shouldBe true
+            }
+            should("not change state when only checking") {
+                rateLimit.wouldAccept() shouldBe true
+                rateLimit.wouldAccept() shouldBe true
+                rateLimit.accept() shouldBe true
+            }
+            should("not allow the next request immediately after one is recorded") {
+                rateLimit.wouldAccept() shouldBe false
+            }
+            clock.elapse(10.ms)
+            should("allow the 2nd request after the minimum interval") {
+                rateLimit.wouldAccept() shouldBe true
+            }
+            should("honor a passed-in minimum interval") {
+                rateLimit.wouldAccept(minInterval = 20.ms) shouldBe false
+            }
+            should("count a recorded request even if it would not have been accepted") {
+                rateLimit.wouldAccept(minInterval = 20.ms) shouldBe false
+                rateLimit.record()
+                rateLimit.wouldAccept() shouldBe false
+            }
+            clock.elapse(10.ms)
+            should("not allow more than maxRequests within the interval (20 ms)") {
+                rateLimit.wouldAccept() shouldBe false
+                rateLimit.accept() shouldBe false
+            }
+            clock.elapse(81.ms)
+            should("allow a request once the 1st has left the interval (101 ms)") {
+                rateLimit.wouldAccept() shouldBe true
+            }
+            val then = clock.instant()
+            clock.elapse(50.ms)
+            should("allow a passed-in time to override the current clock time") {
+                rateLimit.wouldAccept(then.minusMillis(5)) shouldBe false
+                rateLimit.wouldAccept(then) shouldBe true
+                rateLimit.record(then)
+                rateLimit.wouldAccept(then) shouldBe false
+            }
+            should("still read the current clock time afterwards") {
+                rateLimit.wouldAccept() shouldBe true
+                rateLimit.accept() shouldBe true
+                rateLimit.wouldAccept() shouldBe false
+            }
+        }
     }
 }


### PR DESCRIPTION
## Problem

`RateLimit.accept()` checks and records in one step. A caller that gates a request behind more than one `RateLimit` has no way to check all of them before any of them records the request. If the first limit accepts and the second rejects, the first has still counted the request.

This bites in the videobridge's `KeyframeRequester`, which applies a per-receiver limit (3 per 10 s) and then a source-wide limit. A receiver waiting for a keyframe retries on every incoming packet, so when the source-wide limit is closed the receiver burns its 3 per-receiver tokens in a few hundred milliseconds without a single request going out, and is then locked out for 10 s. See jitsi/jitsi-videobridge#2442 for the context.

## Changes

- `wouldAccept(now, minInterval)`: reports whether a request would be accepted, without recording it. Same rules as `accept()`.
- `record(now)`: records a request unconditionally, pruning entries older than `interval`.
- `accept()` is now `wouldAccept` followed by `record` on success. Behavior is unchanged and the existing tests pass untouched.

## Testing

New `Checking without recording` context in `RateLimitTest` covers: checking does not change state, a passed-in `minInterval` is honored, a `record` after a failed check still counts, entries age out of the window, and a passed-in `now` works for both methods. Full test run and ktlint are clean.
