### PR TITLE
Update to Kotlin 2.4.20, JUnit 5.14.4, kotest 5.9.1, mockk 1.14.11, Dokka 2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,12 +43,13 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spotbugs.version>4.8.6</spotbugs.version>
-        <org.junit.version>5.10.0</org.junit.version>
+        <org.junit.version>5.14.4</org.junit.version>
+        <org.junit.platform.version>1.14.4</org.junit.platform.version>
         <java.version>11</java.version>
-        <kotlin.version>1.9.10</kotlin.version>
-        <dokka.version>1.9.10</dokka.version>
-        <kotest.version>5.7.2</kotest.version>
-        <mockk.version>1.13.8</mockk.version>
+        <kotlin.version>2.4.20</kotlin.version>
+        <dokka.version>2.2.0</dokka.version>
+        <kotest.version>5.9.1</kotest.version>
+        <mockk.version>1.14.11</mockk.version>
     </properties>
 
     <dependencies>
@@ -83,8 +84,14 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <version>${org.junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>${org.junit.platform.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -240,6 +247,11 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
+                <configuration>
+                  <systemPropertyVariables>
+                    <kotest.framework.classpath.scanning.autoscan.disable>true</kotest.framework.classpath.scanning.autoscan.disable>
+                  </systemPropertyVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/kotlin/org/jitsi/utils/Instant.kt
+++ b/src/main/kotlin/org/jitsi/utils/Instant.kt
@@ -40,11 +40,11 @@ import java.time.Instant
  */
 fun Instant.toEpochMicro(): Long {
     if (epochSecond < 0 && nano > 0) {
-        val millis = Math.multiplyExact(epochSecond + 1, 1_000_000).toLong()
+        val millis = Math.multiplyExact(epochSecond + 1, 1_000_000)
         val adjustment: Long = (nano / 1_000 - 1).toLong()
         return Math.addExact(millis, adjustment)
     } else {
-        val millis = Math.multiplyExact(epochSecond, 1_000_000).toLong()
+        val millis = Math.multiplyExact(epochSecond, 1_000_000)
         return Math.addExact(millis, (nano / 1000).toLong())
     }
 }


### PR DESCRIPTION
Bumps Kotlin to 2.4.20 and the test and documentation tooling to current versions. Uses the junit-jupiter aggregate artifact and an explicit JUnit platform launcher, disables kotest classpath autoscan, and removes two redundant conversions flagged by the new compiler.

Dokka 2.2.0 is the first release whose embedded analysis understands Kotlin 2.4 metadata; 2.0.0 emits over a hundred "incompatible version of Kotlin" warnings and 2.1.0 crashes on this codebase.

This is one of a set of same-named `kotlin-2.4` branches across jitsi-utils, jitsi-metaconfig, jicoco, jitsi-xmpp-extensions, ice4j, jicofo, jitsi-videobridge and jibri. Each PR only bumps the compiler and test/doc tooling; dependency versions between the jitsi repos are unchanged, so the PRs are independently mergeable. A library built with Kotlin 2.4 can only be consumed by Kotlin 2.3 or newer, so the compiler bumps should land everywhere before any repo picks up a 2.4-built release of another.