### PR TITLE
Run ktlint 1.8.0 directly via exec-maven-plugin and reformat

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,6 @@
 [*.{kt,kts}]    
+# Keep constructor parameters wrapped one per line, and kotest specs unindented.
+ktlint_standard_class-signature = disabled
 max_line_length = 120
 
 ktlint_code_style = intellij_idea

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <dokka.version>2.2.0</dokka.version>
         <kotest.version>5.9.1</kotest.version>
         <mockk.version>1.14.11</mockk.version>
+        <ktlint.version>1.8.0</ktlint.version>
     </properties>
 
     <dependencies>
@@ -223,26 +224,63 @@
                     </compilerArgs>
                 </configuration>
             </plugin>
+            <!-- ktlint: check runs in the verify phase; auto-format with "mvn exec:exec@ktlint-format" -->
             <plugin>
-              <groupId>com.github.gantsign.maven</groupId>
-              <artifactId>ktlint-maven-plugin</artifactId>
-              <version>3.0.0</version>
-              <configuration>
-                <sourceRoots>
-                  <sourceRoot>${project.basedir}/src/main/kotlin</sourceRoot>
-                </sourceRoots>
-                <testSourceRoots>
-                  <testSourceRoot>${project.basedir}/src/test/kotlin</testSourceRoot>
-                </testSourceRoots>
-              </configuration>
-            <executions>
-              <execution>
-                <id>check</id>
-                <goals>
-                  <goal>check</goal>
-                </goals>
-              </execution>
-            </executions>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.6.3</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.pinterest.ktlint</groupId>
+                        <artifactId>ktlint-cli</artifactId>
+                        <version>${ktlint.version}</version>
+                        <classifier>all</classifier>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>ktlint-check</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>java</executable>
+                            <includePluginDependencies>true</includePluginDependencies>
+                            <arguments>
+                                <argument>-classpath</argument>
+                                <classpath>
+                                    <dependency>com.pinterest.ktlint:ktlint-cli</dependency>
+                                </classpath>
+                                <argument>com.pinterest.ktlint.Main</argument>
+                                <argument>--relative</argument>
+                                <argument>src/main/kotlin/**/*.kt</argument>
+                                <argument>src/test/kotlin/**/*.kt</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>ktlint-format</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>java</executable>
+                            <includePluginDependencies>true</includePluginDependencies>
+                            <arguments>
+                                <argument>-classpath</argument>
+                                <classpath>
+                                    <dependency>com.pinterest.ktlint:ktlint-cli</dependency>
+                                </classpath>
+                                <argument>com.pinterest.ktlint.Main</argument>
+                                <argument>--format</argument>
+                                <argument>--relative</argument>
+                                <argument>src/main/kotlin/**/*.kt</argument>
+                                <argument>src/test/kotlin/**/*.kt</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/src/main/kotlin/org/jitsi/utils/Duration.kt
+++ b/src/main/kotlin/org/jitsi/utils/Duration.kt
@@ -127,9 +127,7 @@ private const val NANOS_PER_MILLI = 1_000_000
 private const val MICROS_PER_SECOND = 1_000_000
 private const val NANOS_PER_SECOND = 1_000_000_000
 
-fun Duration.toDouble(): Double {
-    return this.seconds.toDouble() + this.nano.toDouble() * 1e-9
-}
+fun Duration.toDouble(): Double = this.seconds.toDouble() + this.nano.toDouble() * 1e-9
 
 fun Duration.toDoubleMillis(): Double {
     val sec = this.seconds
@@ -173,16 +171,12 @@ fun <T> Iterable<T>.sumOf(selector: (T) -> Duration): Duration {
 /**
  * Returns the maximum of two [Duration]s
  */
-fun max(a: Duration, b: Duration): Duration {
-    return if (a >= b) a else b
-}
+fun max(a: Duration, b: Duration): Duration = if (a >= b) a else b
 
 /**
  * Returns the minimum of two [Duration]s
  */
-fun min(a: Duration, b: Duration): Duration {
-    return if (a <= b) a else b
-}
+fun min(a: Duration, b: Duration): Duration = if (a <= b) a else b
 
 /**
  * Ensures that this value lies in the specified range [minimumValue]..[maximumValue].

--- a/src/main/kotlin/org/jitsi/utils/Instant.kt
+++ b/src/main/kotlin/org/jitsi/utils/Instant.kt
@@ -19,7 +19,7 @@ package org.jitsi.utils
 import java.time.Clock
 import java.time.Instant
 
-/**
+/*
  * Helpers to create instances of [Instant] more easily, and Kotlin operators for it
  */
 
@@ -94,13 +94,9 @@ fun Clock.roundedMillis() = this.instant().toRoundedEpochMilli()
 /**
  * Returns the maximum of two [Instant]s
  */
-fun max(a: Instant, b: Instant): Instant {
-    return if (a >= b) a else b
-}
+fun max(a: Instant, b: Instant): Instant = if (a >= b) a else b
 
 /**
  * Returns the minimum of two [Instant]s
  */
-fun min(a: Instant, b: Instant): Instant {
-    return if (a <= b) a else b
-}
+fun min(a: Instant, b: Instant): Instant = if (a <= b) a else b

--- a/src/main/kotlin/org/jitsi/utils/RangedString.kt
+++ b/src/main/kotlin/org/jitsi/utils/RangedString.kt
@@ -45,12 +45,10 @@ fun Iterator<Int>.joinToRangedString(
     }
 
     var rangeCount = 0
-    fun canAddElement(): Boolean {
-        return when {
-            rangeLimit < 0 -> true
-            rangeCount < rangeLimit -> true
-            else -> false
-        }
+    fun canAddElement(): Boolean = when {
+        rangeLimit < 0 -> true
+        rangeCount < rangeLimit -> true
+        else -> false
     }
 
     var inRange = false
@@ -61,6 +59,7 @@ fun Iterator<Int>.joinToRangedString(
         val element = next()
         when (element) {
             previous + 1 -> inRange = true
+
             else -> {
                 if (inRange) {
                     append(rangeSeparator).append(previous)

--- a/src/main/kotlin/org/jitsi/utils/logging2/LoggerExtensions.kt
+++ b/src/main/kotlin/org/jitsi/utils/logging2/LoggerExtensions.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/**
+/*
  * This file defines additional functions for a lib which is used elsewhere.
  */
 @file:Suppress("unused")

--- a/src/main/kotlin/org/jitsi/utils/stats/BucketStats.kt
+++ b/src/main/kotlin/org/jitsi/utils/stats/BucketStats.kt
@@ -107,6 +107,7 @@ open class BucketStats(
                     val key = "${f}_to_$s"
                     put("$key$bucketLabel", it.second)
                 }
+
                 Format.CumulativeLeft -> {
                     var sum = 0L
                     val f = b.buckets.first().first.first.let { if (it == Long.MIN_VALUE) "min" else "$it" }
@@ -119,6 +120,7 @@ open class BucketStats(
                         }
                     }
                 }
+
                 Format.CumulativeRight -> {
                     var sum = 0L
                     val s = b.buckets.last().first.second.let { if (it == Long.MAX_VALUE) "max" else "$it" }
@@ -215,9 +217,7 @@ class Buckets(private val thresholds: List<Long>) {
             return true
         }
 
-        override fun hashCode(): Int {
-            return buckets.contentHashCode()
-        }
+        override fun hashCode(): Int = buckets.contentHashCode()
     }
 }
 

--- a/src/main/kotlin/org/jitsi/utils/time/FakeClock.kt
+++ b/src/main/kotlin/org/jitsi/utils/time/FakeClock.kt
@@ -36,9 +36,7 @@ class FakeClock(
         }
     }
 
-    override fun instant(): Instant {
-        return now
-    }
+    override fun instant(): Instant = now
 
     fun elapse(duration: Duration) {
         log("elapsing $duration")
@@ -50,9 +48,7 @@ class FakeClock(
         now = instant
     }
 
-    override fun getZone(): ZoneId {
-        return zone_
-    }
+    override fun getZone(): ZoneId = zone_
 
     override fun withZone(zone: ZoneId?): Clock {
         if (zone_ == zone) {

--- a/src/test/kotlin/org/jitsi/utils/stats/MovingAverageTest.kt
+++ b/src/test/kotlin/org/jitsi/utils/stats/MovingAverageTest.kt
@@ -43,14 +43,14 @@ class MovingAverageTest : ShouldSpec() {
                 (4..7).forEach {
                     average.add(it)
                 }
-                average.get() shouldBe (5.5 plusOrMinus(.1))
+                average.get() shouldBe (5.5 plusOrMinus (.1))
             }
             should("not include values outside the window even if no adds have been done") {
                 (0..3).forEach {
                     average.add(it)
                 }
                 fakeClock.elapse(1.mins)
-                average.get() shouldBe(0.0)
+                average.get() shouldBe (0.0)
             }
         }
     }


### PR DESCRIPTION
Replaces the third-party ktlint-maven-plugin, which tends to trail ktlint releases, with the integration ktlint documents itself: the ktlint CLI jar (1.8.0) as an exec-maven-plugin dependency, with the classpath restricted to that jar. The check still runs in the `verify` phase and fails the build on violations. Autoformat with `mvn exec:exec@ktlint-format` instead of `mvn ktlint:format`.

The `class-signature` rule added in ktlint 1.x is disabled in `.editorconfig`: it joins wrapped constructor parameter lists onto one line when they fit and re-indents every kotest spec, which we do not want. All other new rules are applied.

The second commit is the resulting reformat: 53 lines in 7 Kotlin files, almost entirely single-`return` function bodies becoming expression bodies and blank lines between multi-line `when` branches; plus KDoc comments that sat on non-declarations (ktlint cannot auto-correct these) become plain block comments. Behaviour-neutral.

This is one of a set of same-named `ktlint-1.8` branches across jitsi-utils, jitsi-metaconfig, jicoco, jitsi-xmpp-extensions, ice4j, jicofo, jitsi-videobridge and jibri. Each PR is independent; they only change how ktlint is run and apply its formatting.